### PR TITLE
DNS Registration with Route53

### DIFF
--- a/openshift-infra/aws_create_hosts.yml
+++ b/openshift-infra/aws_create_hosts.yml
@@ -6,6 +6,12 @@
     - aws_vars.yml
 
   tasks:
+    - name: Set Hostname Facts
+      set_fact:
+        wildcard_zone: "apps-{{ student_id }}.{{ aws_public_zone }}"
+        openshift_master_cluster_hostname: "master-internal.{{ student_id }}.{{ aws_public_zone }}"
+        openshift_master_cluster_public_hostname: "master-internal.{{ student_id }}.{{ aws_public_zone }}"
+
     - name: Provision AWS Instances
       ec2:
         aws_access_key: "{{ec2_access_key}}"
@@ -36,3 +42,49 @@
         host: "{{ item.instances.0.public_ip }}"
         timeout: 600
       with_items: "{{ instances_created.results }}"
+
+    - name: Register Host DNS
+      route53:
+        command: create
+        aws_access_key: "{{ec2_access_key}}"
+        aws_secret_key: "{{ec2_secret_key}}"
+        zone: "{{ aws_public_zone }}"
+        type: A
+        overwrite: True
+        ttl: 60
+        record: "{{ aws_instances[item.0].name }}-{{ student_id }}.{{ aws_public_zone }}"
+        value: "{{ instances_created.results[item.0]['instances'][0]['public_ip'] }}"
+      register: host_dns_entries
+      with_indexed_items: "{{ aws_instances }}"
+
+    - name: Register Public Environment DNS
+      route53:
+        command: create
+        aws_access_key: "{{ec2_access_key}}"
+        aws_secret_key: "{{ec2_secret_key}}"
+        zone: "{{ aws_public_zone }}"
+        type: A
+        overwrite: True
+        ttl: 60
+        record: "{{ item.1 }}"
+        value: "{{ instances_created.results[aws_instances.index(item.0)]['instances'][0]['public_ip'] }}"
+      with_nested:
+        - "{{ aws_instances }}"
+        - [ "{{ openshift_master_cluster_public_hostname }}", "*.{{ wildcard_zone }}" ]
+      when: "'node_type' in item.0['meta'] and 'master' in item.0['meta']['node_type']"
+
+    - name: Register Private Environment DNS
+      route53:
+        command: create
+        aws_access_key: "{{ec2_access_key}}"
+        aws_secret_key: "{{ec2_secret_key}}"
+        zone: "{{ aws_public_zone }}"
+        type: A
+        overwrite: True
+        ttl: 60
+        record: "{{ item.1 }}"
+        value: "{{ instances_created.results[aws_instances.index(item.0)]['instances'][0]['private_ip'] }}"
+      with_nested:
+        - "{{ aws_instances }}"
+        - [ "{{ openshift_master_cluster_hostname }}" ]
+      when: "'node_type' in item.0['meta'] and 'master' in item.0['meta']['node_type']"

--- a/openshift-infra/aws_lab_launch.yml
+++ b/openshift-infra/aws_lab_launch.yml
@@ -39,3 +39,16 @@
         host: "{{ item.instances.0.public_ip }}"
         timeout: 600
       with_items: "{{ instances_created.results }}"
+    
+    - name: Register DNS Addresses
+      route53:
+        command: create
+        aws_access_key: "{{ec2_access_key}}"
+        aws_secret_key: "{{ec2_secret_key}}"
+        zone: "{{ aws_public_zone }}"
+        type: A
+        overwrite: True
+        ttl: 60
+        record: "tower-{{ lab_creator }}{{ item.0 | int + 1 }}.{{ aws_public_zone }}"
+        value: "{{ instances_created.results[item.0]['instances'][0]['public_ip'] }}"
+      with_indexed_items: instances_created

--- a/openshift-infra/aws_vars.yml
+++ b/openshift-infra/aws_vars.yml
@@ -1,8 +1,9 @@
 ---
 aws_access_key: "{{ec2_access_key}}"
 aws_secret_key: "{{ec2_secret_key}}"
+aws_public_zone: "rhte-apac.sysdeseng.com"
 lab_name: rhte
-lab_creator: isaac
+lab_creator: ablock
 student_count: 1
 domain_name: example.com
 tower_ami_id: ami-03725166

--- a/openshift-infra/my_secrets.yml
+++ b/openshift-infra/my_secrets.yml
@@ -8,3 +8,4 @@ ec2_secret_key: "your_secret_here"
 aws_key_name: #use your key here if you desire
 lab_creator: isaac
 student_count: 1
+public_zone: #specify a different public zone

--- a/openshift-infra/templates/aws_user_data.j2
+++ b/openshift-infra/templates/aws_user_data.j2
@@ -1,6 +1,6 @@
 #cloud-config
 hostname: "{{ item.name }}"
-fqdn: "{{ item.name }}.{{ domain_name }}"
+fqdn: "{{ item.name }}-{{ student_id }}.{{ aws_public_zone }}"
 write_files:
 - path: /etc/sudoers.d/99-ec2-user-requiretty
   permissions: '0440'


### PR DESCRIPTION
Configured various DNS entries with Route53 to support the lab

* Each host gets its own DNS in the form `name`-`student_id`.`dns_zone`
* Master address: `master`-`student_id`.`dns_zone`
* Master Internal Address: `master-internal`-`student_id`.`dns_zone`
   * References Private IP address
* Wildcard Address: `apps`-`student_id`.`dns_zone`

Utilize the following steps to test the PR

* Locally, modify the `lab_creator` value
* Update the `my_secrets.yml` file with your set of values
* Launch the `aws_lab_launch.yml` while also sourcing your `my_secrets.yml` file
* Once tower has been provisioned, it can be accessed by the newly created DNS address
* In tower, modify the AWS group in the OpenShift inventory and update the instance filter with the `student_id` (Should be the value you entered as `lab_creator` previously appended with a 1 [student1 for example])
* In the Projects page, update the _Managing OCP from Install and Beyond_ project with the repository  _https://github.com/sabre1041/managing-ocp-install-beyond.git_ and branch _route53-integration_. Resynchronize the project.
* Launch the _Provision_ job template. In the survey prompt, enter the same student id as previously entered

Verify the job completed successfully. You should see DNS records in Route53 for the new instances