### PR TITLE
adding ability to set up AWS VPC, keypair, sec groups for new regions

### DIFF
--- a/openshift-infra/aws_vars.yml
+++ b/openshift-infra/aws_vars.yml
@@ -46,6 +46,19 @@ aws_az_1: us-east-2a
 aws_sec_group: aws-nyc-loft
 aws_key_name: rhte-apac
 
+# AWS VPC configuration
+# Provide a default name for the VPC
+aws_vpc_name: RHTE-APAC-VPC
+# VPC requires a CIDR block. The key is to ensure that it doesn't conflict with an existing CIDR.
+aws_vpc_cidr_block: 10.10.0.0/16
+# Same as CIDR block
+aws_subnet_cidr: 10.10.0.0/24
+# Name the VPC subnet, route table, security group and provide a security group description.
+aws_subnet_name: "RHTE APAC Public Subnet"
+aws_route_table: "RHTE APAC Public"
+aws_sec_grp: "RHTE APAC Security Group"
+aws_sec_grp_desc: "RHTE APAC Security Group"
+
 ## Tower config - set this to true to run the tower_config.yml playbook to fully configure the Tower instance (this separate playbook can also be run separately
 tower_config: false
 

--- a/openshift-infra/aws_vpc_keypair.yml
+++ b/openshift-infra/aws_vpc_keypair.yml
@@ -1,0 +1,9 @@
+---
+
+- hosts: localhost
+  vars_files:
+    - aws_vars.yml
+
+  roles:
+    - vpc
+    - ec2-security-key

--- a/openshift-infra/roles/ec2-security-key/tasks/main.yml
+++ b/openshift-infra/roles/ec2-security-key/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+
+# roles/ec2-security-key/tasks/main.yml
+
+# Create an AWS keypair.  This should only be done once.
+
+- name:               Create AWS keypair
+  ec2_key:
+    name:             "{{ aws_key_name }}"
+    region:           "{{ aws_region }}"
+    aws_access_key:   "{{ ec2_access_key }}"
+    aws_secret_key:   "{{ ec2_secret_key }}"
+    state:            "present"

--- a/openshift-infra/roles/vpc/tasks/main.yml
+++ b/openshift-infra/roles/vpc/tasks/main.yml
@@ -1,0 +1,136 @@
+---
+
+# roles/vpc/tasks/main.yml
+
+
+# First task : creating the VPC.
+# We are using the variables set in the vars.yml file.
+# The module gives us back its result,
+# which contains information about our new VPC. 
+# We register it in the variable my_vpc.
+
+- name:               Create VPC
+  ec2_vpc_net:
+    name:             "{{ aws_vpc_name }}"
+    cidr_block:       "{{ aws_vpc_cidr_block }}"
+    region:           "{{ aws_region }}"
+    aws_access_key:   "{{ ec2_access_key }}"
+    aws_secret_key:   "{{ ec2_secret_key }}"
+    state:            "present"
+  register: my_vpc
+
+
+# We now use the set_fact module 
+# to save the id of the VPC in a new variable.
+
+- name:               Set VPC ID in variable
+  set_fact:
+    vpc_id:           "{{ my_vpc.vpc.id }}"
+
+
+# Creating our only Subnet in the VPC.
+# A subnet needs to be located in an Availability Zone (or AZ).
+# Again, we register the results in a variable for later.
+
+- name:               Create Public Subnet
+  ec2_vpc_subnet:
+    state:            "present"
+    vpc_id:           "{{ vpc_id }}"
+    cidr:             "{{ aws_subnet_cidr }}"
+    az:               "{{ aws_region }}a"
+    region:           "{{ aws_region }}"
+    aws_access_key:   "{{ ec2_access_key }}"
+    aws_secret_key:   "{{ ec2_secret_key }}"
+    resource_tags:
+      Name:           "{{ aws_subnet_name }}"
+  register: my_public_subnet
+
+
+# We save the id of the Public Subnet in a new variable.
+
+- name:               Set Public Subnet ID in variable
+  set_fact:
+    public_subnet_id: "{{ my_public_subnet.subnet.id }}"
+
+
+# Every VPC needs at least one Internet Gateway.
+# This component allows traffic between the VPC and the outside world.
+
+- name:               Create Internet Gateway for VPC
+  ec2_vpc_igw:
+    vpc_id:           "{{ vpc_id }}"
+    region:           "{{ aws_region }}"
+    aws_access_key:   "{{ ec2_access_key }}"
+    aws_secret_key:   "{{ ec2_secret_key }}"
+    state:            "present"
+  register: my_vpc_igw
+
+
+# We save the id of the Internet Gateway in a new variable.
+
+- name:               Set Internet Gateway ID in variable
+  set_fact:
+    igw_id:           "{{ my_vpc_igw.gateway_id }}"
+
+
+# Now we set up a Route Table. 
+# We attach that Route Table to the Public Subnet.
+# The route we create here defines the default routing 
+# of the table, redirecting requests to the Internet Gateway. 
+# We don't see it here, but the route table will also contain 
+# a route for resources inside the VPC, so that if we need 
+# to reach an internal resource, we don't go to the Internet
+# Gateway.
+
+- name:               Set up public subnet route table
+  ec2_vpc_route_table:
+    vpc_id:           "{{ vpc_id }}"
+    region:           "{{ aws_region }}"
+    aws_access_key:   "{{ ec2_access_key }}"
+    aws_secret_key:   "{{ ec2_secret_key }}"
+    tags:
+      Name:           "{{ aws_route_table }}"
+    subnets:
+      - "{{ public_subnet_id }}"
+    routes:
+      - dest:         "0.0.0.0/0"
+        gateway_id:   "{{ igw_id }}"
+
+
+# Finally, we create our Main Security Group.
+
+- name:               Create Main Security Group
+  ec2_group:
+    name:             "{{ aws_sec_grp }}"
+    description:      "{{ aws_sec_grp_desc }}"
+    vpc_id:           "{{ vpc_id }}"
+    region:           "{{ aws_region }}"
+    aws_access_key:   "{{ ec2_access_key }}"
+    aws_secret_key:   "{{ ec2_secret_key }}"
+    rules:
+      - proto:        "tcp"
+        from_port:    "22"
+        to_port:      "22"
+        cidr_ip:      "0.0.0.0/0"
+      - proto:        "tcp"
+        from_port:    "80"
+        to_port:      "80"
+        cidr_ip:      "0.0.0.0/0"
+      - proto:        "tcp"
+        from_port:    "8080"
+        to_port:      "8080"
+        cidr_ip:      "0.0.0.0/0"
+      - proto:        "tcp"
+        from_port:    "443"
+        to_port:      "443"
+        cidr_ip:      "0.0.0.0/0"
+      - proto:        "tcp"
+        from_port:    "8443"
+        to_port:      "8443"
+        cidr_ip:      "0.0.0.0/0"
+      - proto:        "icmp"
+        from_port:    "8"
+        to_port:      "-1"
+        cidr_ip:      "0.0.0.0/0"
+      - proto:        "all"
+        group_name:   "{{ aws_sec_grp }}"


### PR DESCRIPTION
To test this out:
- Swap over to Nicks new AWS environment.
-- Access us-east-2 region, confirm there is not an existing VPC with the name RHTE-APAC, nor a keypair, nor a security group.
- Add the following variables to your secrets file:

```
# VPC configuration
aws_vpc_name: RHTE-APAC-VPC
aws_vpc_cidr_block: 10.10.0.0/16
aws_subnet_cidr: 10.10.0.0/24
aws_subnet_name: "RHTE APAC Public Subnet"
aws_route_table: "RHTE APAC Public"
aws_sec_grp: "RHTE APAC Security Group"
aws_sec_grp_desc: "RHTE APAC Security Group"
```

- Run the playbook
ansible-playbook -vvv aws_vpc_keypair.yml  -e @<your-name>_secrets.yml

- Go back to AWS console, you should now see VPC, keypair and security group.  On the VPC, you MUST enable auto-assign IPs on the subnet.  Find the subnet with the RHTE-* name and right click on it and enable auto-assign IPs.

