### PR TITLE
Correct accidental tower_config even when false

### DIFF
--- a/openshift-infra/templates/tower_workflow_template_extra_vars.yml
+++ b/openshift-infra/templates/tower_workflow_template_extra_vars.yml
@@ -1,7 +1,6 @@
 ---
 # Put any variables here that will be available to all members of this workflow
-lab_name: "{{ lab_name }}"
 lab_user: "{{ lab_user }}"
 student_id: "{{ student_id }}"
 openshift_deploy_version: "{{ openshift_deploy_version }}"
-domain_name: "{{ domain_name }}"
+openshift_cluster_public_url: "https{{':'}}//master-{{ student_id }}.{{ domain_name }}{{':'}}8443" 

--- a/openshift-infra/tower_config.yml
+++ b/openshift-infra/tower_config.yml
@@ -305,6 +305,10 @@
       command: tower-cli workflow schema {{ tower_workflow_template }} @/tmp/{{ tower_workflow_template_schema_path }}
           "{{ tower_cli_verbosity }}"
 
+    - name: Launch Workflow Job (this may take up to 30 minutes, see Tower UI for progress)
+      command: tower-cli workflow_job launch -W {{ tower_workflow_template }}
+      when: tower_workflow_job_launch
+
     - name: Unset Tower CLI Host
       command: >
         tower-cli config

--- a/openshift-infra/tower_vars.yml
+++ b/openshift-infra/tower_vars.yml
@@ -1,6 +1,5 @@
 ---
 # Tower config
-tower_config: true
 tower_username: admin
 tower_password: rhte2017
 tower_org: "Default"
@@ -62,3 +61,4 @@ tower_workflow_template: "0-Push_Button_Deploy_OpenShift_on_AWS"
 tower_workflow_template_extra_vars: "tower_workflow_template_extra_vars.yml"
 # Wire up job_templates in this file
 tower_workflow_template_schema_path: "tower_workflow_template_schema.yml"
+tower_workflow_job_launch: true


### PR DESCRIPTION
* Also adds variable tower_workflow_job_launch to launch workflow at end
of tower config
* Clean up extra_vars for workflow
* Add openshift_cluster_public_url to workflow for students to access

To test set `tower_config: true` and run. The result should be a fully configured Tower that kicks off the OCP Install job template. (Optionally set `tower_workflow_job_launch` to False in you vars file if desired and the workflow job will not run automatically).

Next, login to Tower and click *Jobs* and verify the workflow and job are running. Under Workflow, verify there is a variable `openshift_cluster_public_url`, this should open the OCP console once installed.

Optionally try setting `student_count` to something higher than 1 and ensure all the clusters come up.