### PR TITLE
Change region info to new APAC region

### DIFF
--- a/openshift-infra/aws_vars.yml
+++ b/openshift-infra/aws_vars.yml
@@ -16,7 +16,7 @@ openshift_master_dns_prefix: "master"
 openshift_master_internal_dns_prefix: "master-internal"
 
 ## Domain to use for wildcard
-domain_name: rhte-apac.sysdeseng.com
+domain_name: rhte.sysdeseng.com
 
 ## AWS credentials (do not save it here, instead override with -e)
 aws_access_key: "{{ec2_access_key}}"
@@ -24,7 +24,7 @@ aws_secret_key: "{{ec2_secret_key}}"
 
 ## Set the AMI IDs here (or override with -e). Some commonly used AMIs are defined here, but ultimately the ones that matter are 'tower_ami_id' and 'ocp_ami_id'
 ## Tower AMI unconfigured
-tower_ami_id_unconfigured: ami-d90427bc
+tower_ami_id_unconfigured: ami-a31676c0
 ## Tower AMI ID fully configured
 tower_ami_id_configured: ami-800a29e5
 ## Tower AMI ID - This is the only variable used in the Playbooks, set it to one of the above (or override with -e)
@@ -32,7 +32,7 @@ tower_ami_id: "{{ tower_ami_id_unconfigured }}"
 ## OCP 3.5 ID
 ocp_ami_id_3_5: ami-3934175c
 ## OCP 3.6 ID
-ocp_ami_id_3_6: ami-9e3417fb
+ocp_ami_id_3_6: ami-4b600028
 ## OCP ID - This is the only variable used in the Playbooks, set it to one of the above (or override with -e)
 ocp_ami_id: "{{ ocp_ami_id_3_6 }}"
 

--- a/openshift-infra/aws_vars.yml
+++ b/openshift-infra/aws_vars.yml
@@ -40,13 +40,14 @@ ocp_ami_id: "{{ ocp_ami_id_3_6 }}"
 tower_inst_type: t2.medium
 ocp_master_inst_type: t2.large
 ocp_node_inst_type: t2.xlarge
-aws_subnet_id: subnet-bf7125d6
-aws_region: us-east-2
-aws_az_1: us-east-2a
+# The subnet_id can be dynamically set if initially creating it at the same time with the aws_vpc_keypair.yml playbook. Setting is statically for now
+aws_subnet_id: subnet-dba04d92
+aws_region: ap-southeast-1
+aws_az_1: "{{ aws_region }}a"
 aws_sec_group: "rhte-apac-security-group"
 aws_key_name: rhte-apac
 
-# AWS VPC configuration
+# AWS VPC configuration - this is used to setup a new Region
 # Provide a default name for the VPC
 aws_vpc_name: RHTE-APAC-VPC
 # VPC requires a CIDR block. The key is to ensure that it doesn't conflict with an existing CIDR.
@@ -56,7 +57,6 @@ aws_subnet_cidr: 10.10.0.0/24
 # Name the VPC subnet, route table, security group and provide a security group description.
 aws_subnet_name: "RHTE APAC Public Subnet"
 aws_route_table: "RHTE APAC Public"
-aws_sec_group_description: "{{ aws_sec_group }}"
 
 ## Tower config - set this to true to run the tower_config.yml playbook to fully configure the Tower instance (this separate playbook can also be run separately
 tower_config: false

--- a/openshift-infra/aws_vars.yml
+++ b/openshift-infra/aws_vars.yml
@@ -24,7 +24,7 @@ aws_secret_key: "{{ec2_secret_key}}"
 
 ## Set the AMI IDs here (or override with -e). Some commonly used AMIs are defined here, but ultimately the ones that matter are 'tower_ami_id' and 'ocp_ami_id'
 ## Tower AMI unconfigured
-tower_ami_id_unconfigured: ami-a31676c0
+tower_ami_id_unconfigured: ami-7c65051f
 ## Tower AMI ID fully configured
 tower_ami_id_configured: ami-800a29e5
 ## Tower AMI ID - This is the only variable used in the Playbooks, set it to one of the above (or override with -e)
@@ -45,7 +45,7 @@ aws_subnet_id: subnet-dba04d92
 aws_region: ap-southeast-1
 aws_az_1: "{{ aws_region }}a"
 aws_sec_group: "rhte-apac-security-group"
-aws_key_name: rhte-apac
+aws_key_name: rhte
 
 # AWS VPC configuration - this is used to setup a new Region
 # Provide a default name for the VPC

--- a/openshift-infra/roles/vpc/tasks/main.yml
+++ b/openshift-infra/roles/vpc/tasks/main.yml
@@ -102,7 +102,7 @@
 - name:               Create Main Security Group
   ec2_group:
     name:             "{{ aws_sec_group }}"
-    description:      "{{ aws_sec_group_description }}"
+    description:      "{{ aws_sec_group }}"
     vpc_id:           "{{ vpc_id }}"
     region:           "{{ aws_region }}"
     aws_access_key:   "{{ ec2_access_key }}"


### PR DESCRIPTION
This PR sets the `aws_vars.yml` variables for the new APAC environment. Running `aws_vpc_keypair.yml` with this PR should not change anything as the objects are already there. Running `aws_lab_launch.yml` will not work until the AMIs are copied over and updated.