### PR TITLE
Post install tasks

### DIFF
--- a/openshift-infra/openshift_postinstall.yml
+++ b/openshift-infra/openshift_postinstall.yml
@@ -1,0 +1,48 @@
+---
+- hosts: masters
+  vars:
+    templates_query: '{range .items[*]}{.metadata.name}{"\n"}{end}'
+    image_streams_query: '{range .items[*]}{.metadata.name}{"\n"}{end}'
+    templates_to_keep: ['cakephp-mysql-persistent', 'metrics-deployer-template', 'registry-console']
+    image_streams_to_keep: ['php', 'mysql']
+    cfme_template: https://raw.githubusercontent.com/openshift/openshift-ansible/release-3.6/roles/openshift_examples/files/examples/v3.6/cfme-templates/cfme-template.yaml
+  tasks:
+  - name: Get templates
+    command: >
+      oc get templates -n openshift -o jsonpath='{{ templates_query }}'
+    register: templates
+
+  - name: Remove templates
+    command: >
+      oc delete templates -n openshift {{ item }}
+    when: item not in templates_to_keep
+    with_items:
+    - "{{ templates.stdout_lines }}"
+
+  - name: Get ImageStreams
+    command: >
+      oc get is -n openshift -o jsonpath='{{ image_streams_query }}'
+    register: image_streams
+
+  - name: Remove ImageStreams
+    command: >
+      oc delete is -n openshift {{ item }}
+    when: item not in image_streams_to_keep
+    with_items:
+      - "{{ image_streams.stdout_lines }}"
+
+  - name: Delete image stream tags not needed
+    command: >
+      oc tag {{ item }} -d
+    register: tag_delete
+    failed_when: tag_delete.rc != 0 and 'not found' not in tag_delete.stderr
+    changed_when: tag_delete.rc == 0
+    with_items:
+    - openshift/php:5.5
+    - openshift/php:5.6
+    - openshift/mysql:5.5
+    - openshift/mysql:5.6
+
+  - name: Setup CFME Template
+    command: >
+      oc apply -n openshift -f {{ cfme_template }}


### PR DESCRIPTION
Tasks to configure the cluster post installation

An additional task to add a job template in tower will need to be completed

**Testing Instructions**

Login to Tower and add a new Project. Click **Project** and then click **New**. Enter a _name_ (Post Install) and then from the SCM type dropdown, select **Git**. 

* In the _SCM Url_ field, enter `https://github.com/sabre1041/managing-ocp-install-beyond.git`
* In the _SCM Branch_ field, enter `postinstall-updated`

Make sure **Clean** and **Update on Launch** are checked. Click **Save** to add the new project.

Add a new Template by clicking on the **Template** tab at the top. Locate the _1-Provision_ template and then select the **Copy Template** button. This will help reduce the number of steps necessary. 

The newly created template edit page will appear. Change the name of the template to **3-Post Install**. Under _Project_, select the magnifying glass and select **Post Install** (or the name you gave the project earlier). 

Check **Enable privilege escalation** and then click **Save**

Execute the template by clicking the _Rocket Ship_.

Once successful, log in to OpenShift and confirm the majority of the templates have been removed keeping the _Cake PHP + MySQL Persistent_ and _cloudforms_ templates are present.