### PR TITLE
Service catalog and postinstall

### DIFF
--- a/openshift-infra/openshift_postinstall.yml
+++ b/openshift-infra/openshift_postinstall.yml
@@ -5,6 +5,9 @@
     image_streams_query: '{range .items[*]}{.metadata.name}{"\n"}{end}'
     templates_to_keep: ['cakephp-mysql-persistent', 'metrics-deployer-template', 'registry-console']
     image_streams_to_keep: ['php', 'mysql']
+    service_catalog_projects_to_annotate: ['kube-service-catalog']
+    default_node_selector: 'type=app'
+    service_catalog_default_node_selector: 'openshift-infra=apiserver'
     cfme_template: https://raw.githubusercontent.com/openshift/openshift-ansible/release-3.6/roles/openshift_examples/files/examples/v3.6/cfme-templates/cfme-template.yaml
   tasks:
   - name: Get templates
@@ -46,3 +49,28 @@
   - name: Setup CFME Template
     command: >
       oc apply -n openshift -f {{ cfme_template }}
+  
+  - name: Annotate Service Catalog Projects
+    command: >
+      oc annotate namespace {{ item }} openshift.io/node-selector='{{ service_catalog_default_node_selector }}' --overwrite
+    with_items: "{{ service_catalog_projects_to_annotate }}"
+
+  - name: Set Default Node Selector
+    lineinfile: dest=/etc/origin/master/master-config.yaml  state=present regexp="defaultNodeSelector" line='  defaultNodeSelector{{ ':' }} {{ default_node_selector }}'
+  
+  - name: Restart OpenShift Master
+    systemd:
+      name: atomic-openshift-master
+      state: restarted
+    when: "groups['masters'] | length  == 1"
+
+  - name: Restart OpenShift Master API
+    systemd:
+      name: atomic-openshift-master-api
+      state: restarted
+    when: "groups['masters'] | length > 1"
+
+  - name: Delete Service Catalog Pods
+    command: >
+      oc delete pods --all -n {{ item}}
+    with_items: "{{ service_catalog_projects_to_annotate }}"

--- a/openshift-infra/openshift_postinstall.yml
+++ b/openshift-infra/openshift_postinstall.yml
@@ -56,15 +56,18 @@
     with_items: "{{ service_catalog_projects_to_annotate }}"
 
   - name: Set Default Node Selector
+    become: true
     lineinfile: dest=/etc/origin/master/master-config.yaml  state=present regexp="defaultNodeSelector" line='  defaultNodeSelector{{ ':' }} {{ default_node_selector }}'
   
   - name: Restart OpenShift Master
+    become: true
     systemd:
       name: atomic-openshift-master
       state: restarted
     when: "groups['masters'] | length  == 1"
 
   - name: Restart OpenShift Master API
+    become: true
     systemd:
       name: atomic-openshift-master-api
       state: restarted

--- a/openshift-infra/openshift_postinstall.yml
+++ b/openshift-infra/openshift_postinstall.yml
@@ -58,6 +58,11 @@
   - name: Set Default Node Selector
     become: true
     lineinfile: dest=/etc/origin/master/master-config.yaml  state=present regexp="defaultNodeSelector" line='  defaultNodeSelector{{ ':' }} {{ default_node_selector }}'
+
+  - name: Locate OpenShift API Server
+    command: >
+      oc whoami --show-server=true
+    register: whoami_result
   
   - name: Restart OpenShift Master
     become: true
@@ -72,6 +77,20 @@
       name: atomic-openshift-master-api
       state: restarted
     when: "groups['masters'] | length > 1"
+
+  - name: Verify API Server
+    become: true
+    command: >
+      curl --silent
+      --cacert /etc/origin/master/ca-bundle.crt
+      {{ whoami_result.stdout }}/healthz/ready
+    args:
+      warn: no
+    register: l_api_available_output
+    until: l_api_available_output.stdout == 'ok'
+    retries: 120
+    delay: 1
+    changed_when: false
 
   - name: Delete Service Catalog Pods
     command: >

--- a/openshift-infra/templates/OSEv3.yml.j2
+++ b/openshift-infra/templates/OSEv3.yml.j2
@@ -12,7 +12,6 @@ openshift_master_htpasswd_users:
   user1: $apr1$7ctI4q/Q$84OX0FrpqM3hzlO9CUCh0.
 openshift_master_image_policy_config:
   maxImagesBulkImportedPerRepository: 100
-osm_default_node_selector: 'type=app'
 openshift_hosted_metrics_deploy: yes
 openshift_hosted_metrics_storage_kind: dynamic
 os_sdn_network_plugin_name: redhat/openshift-ovs-multitenant
@@ -26,8 +25,12 @@ openshift_master_cluster_hostname: "{{ openshift_master_internal_dns_prefix }}-{
 openshift_master_cluster_public_hostname: "{{ openshift_master_dns_prefix }}-{{ student_id }}.{{ domain_name }}"
 openshift_metrics_cassandra_storage_type: dynamic
 openshift_disable_check: memory_availability
+openshift_enable_service_catalog: true
 {% raw %}
 openshift_cloudprovider_aws_access_key: "{{ lookup('env','AWS_ACCESS_KEY') }}"
 openshift_cloudprovider_aws_secret_key: "{{ lookup('env','AWS_SECRET_KEY') }}"
 openshift_node_labels: "{{ ec2_tag_node_labels }}"
 {% endraw %}
+
+# Default Node Selector Cannot be Used Due to Issue With Service Catalog Deployment. Is set during Postinstall playbook
+#osm_default_node_selector: 'type=app'


### PR DESCRIPTION
Steps to deploy and enable the service catalog and ansible-service broker.

### To Test

* Deploy a new instance of Tower
* Navigate to _Projects_ and edit the _Managing OCP from Install and Beyond_ project
    ** Set the branch to **service-catalog-and-postinstall**
* Run the **1-Deploy_OpenShift_on_AWS** Workflow Job Template

### Validate

* Verify Service Catalog UI now present in OpenShift Web Console
* Verify all pods are running in the _kube-service-catalog_ project
* Verify _defaultNodeSelector_ in _/etc/origin/master/master-config.yaml_ is set to **type=app**