### PR TITLE
Corret route53 loop to properly create entries for tower instances

### DIFF
--- a/openshift-infra/aws_lab_launch.yml
+++ b/openshift-infra/aws_lab_launch.yml
@@ -51,18 +51,29 @@
       var: groups
       verbosity: 2
 
-  - name: Register DNS Addresses
-    route53:
-      command: create
-      aws_access_key: "{{ec2_access_key}}"
-      aws_secret_key: "{{ec2_secret_key}}"
-      zone: "{{ domain_name }}"
-      type: A
-      overwrite: True
-      ttl: 60
-      record: "tower-{{ lab_user }}-{{ item.0 | int + 1 }}.{{ domain_name }}"
-      value: "{{ instances_created.results[item.0]['instances'][0]['public_ip'] }}"
-    with_indexed_items: instances_created
+- name: Create AWS route53 entries for Tower instances
+  hosts: tower_instances
+  gather_facts: no
+  vars_files:
+    - aws_vars.yml
+
+  tasks:
+    - debug:
+        var: hostvars
+        verbosity: 2
+
+    - name: Register route53 entries
+      local_action:
+        module: route53
+        command: create
+        aws_access_key: "{{ec2_access_key}}"
+        aws_secret_key: "{{ec2_secret_key}}"
+        zone: "{{ domain_name }}"
+        type: A
+        overwrite: True
+        ttl: 60
+        record: "tower-{{ hostvars[inventory_hostname].student_id }}.{{ domain_name }}"
+        value: "{{ hostvars[inventory_hostname].public_ip }}"
 
 # It seems this when conditional is ignored, so will always run tower_config. Will refactor into a role in a future Pr
 - include: tower_config.yml


### PR DESCRIPTION
To test, set the following variables:

```
tower_config: false
student_count: 2 # or any higher number
```

- Check AWS route53 entries before and after running `aws_lab_lanunch.yml` to verify all tower entries are created.