### PR TITLE
Update tower ami with fixed scaleup

### DIFF
--- a/openshift-infra/aws_vars.yml
+++ b/openshift-infra/aws_vars.yml
@@ -24,7 +24,7 @@ aws_secret_key: "{{ec2_secret_key}}"
 
 ## Set the AMI IDs here (or override with -e). Some commonly used AMIs are defined here, but ultimately the ones that matter are 'tower_ami_id' and 'ocp_ami_id'
 ## Tower AMI unconfigured
-tower_ami_id_unconfigured: ami-7c65051f
+tower_ami_id_unconfigured: ami-fee98b9d
 ## Tower AMI ID fully configured
 tower_ami_id_configured: ami-800a29e5
 ## Tower AMI ID - This is the only variable used in the Playbooks, set it to one of the above (or override with -e)

--- a/openshift-infra/tower_config.yml
+++ b/openshift-infra/tower_config.yml
@@ -241,6 +241,7 @@
         name: "{{ tower_project_install_package }}"
         state: present
       become: true
+      when: tower_install_playbooks| bool == true
 
     - name: Create symbolic link to /usr/share
       file:

--- a/openshift-infra/tower_vars.yml
+++ b/openshift-infra/tower_vars.yml
@@ -52,6 +52,7 @@ tower_project_provision_and_configure_update_on_launch: "yes"
 tower_project_provision_and_configure_delete_on_update: "no"
 
 # Tower project for install
+tower_install_playbooks: false
 tower_project_install_package: "openshift-ansible-playbooks"
 tower_project_install: "openshift-ansible"
 tower_project_install_description: "Red Hat OpenShift Container Platform Ansible Playbooks"


### PR DESCRIPTION
This PR updates the Tower AMI to `tower_ami_id_unconfigured: ami-fee98b9d` which contains the following fix:

The Tower AMI now has the repo for OCP 3.6 enabled, and `openshift-ansible-playbooks` installed.

I've also modified `/usr/share/ansible/openshift-ansible/roles/openshift_node_certificates/tasks/main.yml` and added the following at line 52:

```

# added by vvaldez per github issue 4442
- name: Check if ca-bundle.crt exists on openshift_ca_host
  stat:
    path: /etc/origin/master/ca-bundle.crt
  register: ca_bundle_cert_stat_result
  delegate_to: "{{ openshift_ca_host }}"
  run_once: true

- name: Overwrite cat.crt with ca-bundle.crt per github issue 4442
  shell: "cat /etc/origin/master/ca-bundle.crt > /etc/origin/master/ca.crt"
  delegate_to: "{{ openshift_ca_host }}"
  when: ca_bundle_cert_stat_result.stat.exists | bool
  run_once: true
# end addition by vvaldez per github issue 4442
```
This allows scaleup to work properly.

To test, set the following variables:

```
tower_config: true
tower_workflow_job_deploy_launch: true
tower_workflow_job_scaleup_launch: true
```

Verify scaleup job template succeeded (not the workflow)

You should also see 3 nodes with the command:
```
[ec2-user@master-vvaldez-1 ~]$ oc get nodes
NAME                                             STATUS    AGE       VERSION
ip-10-10-0-103.ap-southeast-1.compute.internal   Ready     30m       v1.6.1+5115d708d7
ip-10-10-0-151.ap-southeast-1.compute.internal   Ready     30m       v1.6.1+5115d708d7
ip-10-10-0-180.ap-southeast-1.compute.internal   Ready     4m        v1.6.1+5115d708d7
```