### PR TITLE
Replace OCP user to be the unique <student_id>

### DIFF
--- a/labs/lab1/chapter1.adoc
+++ b/labs/lab1/chapter1.adoc
@@ -62,7 +62,7 @@ Add a new group called _OSEv3_ which will be used as the top level group referen
 * Click **ADD GROUP**
 ** Provide a name of **OSEv3**
 ** Choose a _SOURCE_ of **Manual*
-** Copy the following variables to the inventory script.  “REPLACE <student_id> with your student ID! student_id takes for form similar to student-1 as used previously. There are **3** instances of <student_id> in the variables below - be sure to change each of them.
+** Copy the following variables to the inventory script.  “REPLACE <student_id> with your student ID! student_id takes for form similar to student-1 as used previously. There are **4** instances of <student_id> in the variables below - be sure to change each of them.
 
 +
 [source, bash]
@@ -78,7 +78,7 @@ openshift_master_identity_providers:
   kind: HTPasswdPasswordIdentityProvider
   filename: /etc/origin/master/htpasswd
 openshift_master_htpasswd_users:
-  student: $apr1$5/tyREyX$faNZX.wbId4LGDkNYxJQZ0
+  <student_id>: $apr1$5/tyREyX$faNZX.wbId4LGDkNYxJQZ0
 openshift_master_image_policy_config:
   maxImagesBulkImportedPerRepository: 100
 openshift_hosted_metrics_deploy: yes

--- a/labs/lab6/chapter6.adoc
+++ b/labs/lab6/chapter6.adoc
@@ -52,7 +52,7 @@ Perform these steps from the Ansible Tower host
 ----
 ec2_access_key: "{{ lookup('env', 'AWS_ACCESS_KEY') }}"
 ec2_secret_key: "{{ lookup('env', 'AWS_SECRET_KEY') }}"
-student_id: <YOUR STUDENT ID>
+student_id: <student_id>
 openshift_cluster_public_url: "https{{':'}}//master-{{ student_id }}.{{ domain_name }}{{':'}}8443"
 ----
 
@@ -91,7 +91,7 @@ openshift_cluster_public_url: "https{{':'}}//master-{{ student_id }}.{{ domain_n
 
 Once again, using the web browser from the student machine, navigate to the Ansible Tower instance:
 
-link:https://tower-<Student-ID>.rhte.sysdeseng.com[https://<student_id>.rhte.sysdeseng.com] 
+link:https://tower-<student_id>.rhte.sysdeseng.com[https://<student_id>.rhte.sysdeseng.com] 
 
 If the web session has not been retained from a prior lab, login with the following credentials:
 

--- a/templates/OSEv3.yml.j2
+++ b/templates/OSEv3.yml.j2
@@ -9,7 +9,7 @@ openshift_master_identity_providers:
   kind: HTPasswdPasswordIdentityProvider
   filename: /etc/origin/master/htpasswd
 openshift_master_htpasswd_users:
-  student: $apr1$5/tyREyX$faNZX.wbId4LGDkNYxJQZ0
+  {{ student_id }}: $apr1$5/tyREyX$faNZX.wbId4LGDkNYxJQZ0
 openshift_master_image_policy_config:
   maxImagesBulkImportedPerRepository: 100
 openshift_hosted_metrics_deploy: yes


### PR DESCRIPTION
This PR changes the OCP user from `student` to the dynamic value of `<student_id>`. 

To test, set these variables:

```
tower_config: true
tower_workflow_job_deploy_launch: true
```
Without waiting for the full OCP install, you can login to Tower and edit the `OSEv3` inventory and verify the user is set in the variables section.

Once OCP install is finished, ensure the `<student_id>` can login.