### PR TITLE
Fix missing source region for AWS inventory in Tower

### DIFF
--- a/roles/tower_config/tasks/inventory/groups.yml
+++ b/roles/tower_config/tasks/inventory/groups.yml
@@ -12,6 +12,7 @@
     instance_filters: "{{ filter }}"
     update_on_launch: "{{ tower_inventory_group_update_on_launch }}"
     overwrite: "{{ tower_inventory_group_overwrite }}"
+    source_regions: "{{ aws_region }}"
     source_vars:
       regions: "{{ aws_region }}"
       vpc_destination_variable: public_dns_name


### PR DESCRIPTION
Addresses #99 

To test run `aws_lab_launch.yml` with these variables:
```
tower_password: "password"
tower_config: true
tower_config_type: self
tower_project_provision_and_configure_url: "https://github.com/vvaldez/summit-2017-ocp-operator.git"
tower_project_provision_and_configure_branch: "fix-inventory-source-region"
```
Go to `Inventories` then edit `AWS` and verify the `Regions` value is populated.

Optionally, to re-create the original issue create a Tower instance with one `student_id` in one region, then attempt to deploy with either `self`, `full` or `test` in another region with the same `student_id`.