### PR TITLE
Become more AWS region agnostic

### DIFF
--- a/aws_vars.yml
+++ b/aws_vars.yml
@@ -26,40 +26,32 @@ aws_access_key: "{{ec2_access_key}}"
 aws_secret_key: "{{ec2_secret_key}}"
 
 ## Set the AMI IDs here (or override with -e). Some commonly used AMIs are defined here, but ultimately the ones that matter are 'tower_ami_id' and 'ocp_ami_id'
-## Tower AMI unconfigured
-tower_ami_id_unconfigured: ami-29610c4a
-## Tower AMI ID fully configured
-tower_ami_id_configured: ami-800a29e5
 ## Tower AMI ID - This is the only variable used in the Playbooks, set it to one of the above (or override with -e)
-tower_ami_id: "{{ tower_ami_id_unconfigured }}"
-## OCP 3.5 ID
-ocp_ami_id_3_5: ami-3934175c
-## OCP 3.6 ID
-ocp_ami_id_3_6: ami-7975151a
+tower_ami_id: "{{ tower_ami_id }}"
 ## OCP ID - This is the only variable used in the Playbooks, set it to one of the above (or override with -e)
-ocp_ami_id: "{{ ocp_ami_id_3_6 }}"
+ocp_ami_id: "{{ ocp_ami_id }}"
 
 ## AWS Info
 tower_inst_type: t2.medium
 ocp_master_inst_type: t2.large
 ocp_node_inst_type: t2.xlarge
 # The subnet_id can be dynamically set if initially creating it at the same time with the aws_vpc_keypair.yml playbook. Setting is statically for now
-aws_subnet_id: subnet-dba04d92
-aws_region: ap-southeast-1
+aws_subnet_id: "{{ aws_subnet_id }}"
+aws_region: "{{ aws_region }}"
 aws_az_1: "{{ aws_region }}a"
-aws_sec_group: "rhte-apac-security-group"
+aws_sec_group: "{{ aws_sec_group }}"
 aws_key_name: rhte
 
 # AWS VPC configuration - this is used to setup a new Region
 # Provide a default name for the VPC
-aws_vpc_name: RHTE-APAC-VPC
+aws_vpc_name: aws_vpc_name
 # VPC requires a CIDR block. The key is to ensure that it doesn't conflict with an existing CIDR.
-aws_vpc_cidr_block: 10.10.0.0/16
+aws_vpc_cidr_block: "{{ aws_vpc_cidr_block }}"
 # Same as CIDR block
-aws_subnet_cidr: 10.10.0.0/24
+aws_subnet_cidr: "{{ aws_subnet_cidr }}"
 # Name the VPC subnet, route table, security group and provide a security group description.
-aws_subnet_name: "RHTE APAC Public Subnet"
-aws_route_table: "RHTE APAC Public"
+aws_subnet_name: "{{ aws_subnet_name }}"
+aws_route_table: "{{ aws_route_table }}"
 
 ## Tower config - set this to true to run the tower_config.yml playbook to fully configure the Tower instance (this separate playbook can also be run separately
 tower_config: false

--- a/aws_vars.yml
+++ b/aws_vars.yml
@@ -40,7 +40,7 @@ aws_subnet_id: "{{ aws_subnet_id }}"
 aws_region: "{{ aws_region }}"
 aws_az_1: "{{ aws_region }}a"
 aws_sec_group: "{{ aws_sec_group }}"
-aws_key_name: rhte
+aws_key_name: "{{ aws_key_name }}"
 
 # AWS VPC configuration - this is used to setup a new Region
 # Provide a default name for the VPC

--- a/my_secrets.yml
+++ b/my_secrets.yml
@@ -3,9 +3,33 @@
 # 
 # ansible-playbook -e @my_secrets.yml <other parameters> ...
 
+# AWS Key configuration
+# AWS Account #1
 ec2_access_key: "your_access_key_here"
 ec2_secret_key: "your_secret_key_here"
+
+# AWS Account #2
+# ec2_access_key: "your_access_key_here"
+# ec2_secret_key: "your_secret_key_here"
+
+# General parameters
 aws_key_name: "your_SSH_key_name_here"
 lab_user: student
 student_count: 1
-tower_password: "password here"
+tower_config: "configure_tower ex: true,false"
+tower_config_type: "type_of_deployment_here ex: test,full,self,none"
+
+# AWS location information
+aws_vpc_name: "vpc_id_here ex: RHTE-emea-VPC"
+aws_route_table: "route_table_here ex: RHTE EMEA Public"
+aws_subnet_id: "subnet_id_here ex: subnet-e4f8098f"
+aws_region: "region_here ex: eu-central-1"
+aws_sec_group: "security_group_here ex: rhte-emea-security-group"
+aws_vpc_name: "vpc_name_here ex: RHTE-emea-VPC"
+aws_vpc_cidr_block: "vpc_cidr_here ex: 10.30.0.0/16"
+aws_subnet_cidr: "subnet_cidr_here ex: 10.30.0.0/24"
+aws_subnet_name: "subnet_name_here ex: RHTE EMEA Public Subnet"
+
+# AMI configuration
+tower_ami_id: "tower_AMI_id_here ex: ami-0167d06e"
+ocp_ami_id: "ocp_ami_id_here ex: ami-4267d02d"


### PR DESCRIPTION
To enable multi-region support, we must have AWS location information in our secrets file, and not defaulted to in the main aws_vars.yml file

Your secrets fill will look something like this:

```
# General parameters
tower_password: "<CURRENT PASSWORD>"
tower_config: true
tower_config_type: self
lab_user: scollier-test
student_count: 2
#student_count_start: 4
#student_count_end: 6

# AWS location information
aws_vpc_name: "RHTE-emea-VPC"
aws_subnet_id: "subnet-e4XXXXX98f"
aws_region: "eu-central-1"
aws_sec_group: "rhte-emea-security-group"
aws_vpc_name: "RHTE-emea-VPC"
aws_vpc_cidr_block: "10.30.0.0/16"
aws_subnet_cidr: "10.30.0.0/24"
aws_subnet_name: "RHTE EMEA Public Subnet"
aws_route_table: "RHTE EMEA Public"
# END OF AWS VPC configuration

# AMI configuration
tower_ami_id: ami-0167d06e
ocp_ami_id: ami-4267d02d
```