### PR TITLE
Update Tower username and other minor doc updates

### DIFF
--- a/labs/lab0/lab0.adoc
+++ b/labs/lab0/lab0.adoc
@@ -47,11 +47,11 @@ The following table outlines how to connect to each resource:
 | *Item* | *URL* | *Access*
 | Ansible Tower|
 link:https://tower-<student_id>.rhte.sysdeseng.com[https://tower-<student_id>.rhte.sysdeseng.com] |
-Username: admin +
+Username: <student_id> +
 Password: INSTRUCTOR WILL PROVIDE
 | OpenShift Container Platform |
 link:https://:master-<student_id>.rhte.sysdeseng.com:8443[https://master-<student_id>.rhte.sysdeseng.com:8443] |
-Username: student +
+Username: <student_id> +
 Password: INSTRUCTOR WILL PROVIDE
 | Red Hat CloudForms |
 link:https://cloudforms-cloudforms.apps-<student_id>.rhte.sysdeseng.com[https://cloudforms-cloudforms.apps-<student_id>.rhte.sysdeseng.com] |

--- a/labs/lab1/lab1.adoc
+++ b/labs/lab1/lab1.adoc
@@ -20,7 +20,7 @@ A link:http://docs.ansible.com/ansible-tower/latest/html/userguide/job_templates
 
 From the Tower overview page, select **TEMPLATES**.
 
-A single Job Template called _0-Self-Configure_ is available that will finalize the rest of the setup. Click the **RocketShip** to launch the template.
+A single Job Template called _0-Self-Configure_ is available that will finalize the rest of the setup. Click the **RocketShip** to launch the template. Feel free to review the details of the playbook while it is running from here: link:https://github.com/sabre1041/managing-ocp-install-beyond/tree/rhte/roles/tower_config/tasks[Tower Config]
 
 image::images/job-template-tower-config.png[]
 

--- a/labs/lab2/lab2.adoc
+++ b/labs/lab2/lab2.adoc
@@ -37,16 +37,16 @@ Once logged into Ansible Tower, explore the CLI.
 .tower$
 [source, bash]
 ----
-sudo tower-cli --help
-sudo tower-cli version
-sudo tower-cli host list
-sudo tower-cli inventory list
-sudo tower-cli job list
-sudo tower-cli credential list
-sudo tower-cli job_template list
-sudo tower-cli group list
-sudo tower-cli workflow list
-sudo tower-cli project list
+tower-cli --help
+tower-cli version
+tower-cli host list
+tower-cli inventory list
+tower-cli job list
+tower-cli credential list
+tower-cli job_template list
+tower-cli group list
+tower-cli workflow list
+tower-cli project list
 ----
 
 ==== Accessing Ansible Tower Web Console
@@ -61,7 +61,7 @@ image::images/ansible-tower-overview.png[]
 
 ====== Job Templates
 
-First, let’s review the job template that was just executed to provision the OpenShift Container Platform. This workflow template consists of three chained job templates:
+First, let's review the job template that was just executed to provision the OpenShift Container Platform. This workflow template consists of three chained job templates:
 
 * Deploy-1-Provision - Prepares the AWS environment by provisioning two instances, a master and a node
 * Deploy-2-Install - This step utilizes a dynamic inventory of AWS and then installs the OpenShift Container Platform on the instances provisioned previously


### PR DESCRIPTION
Minor updates including username from admin to <student_id> and removing sudo from `tower-cli` commands since auth is only saved for `ec2-user` and not `root`.