### PR TITLE
This PR updates of Tower from 3.1.4 to 3.2.2

### DIFF
--- a/aws_vars.yml
+++ b/aws_vars.yml
@@ -12,14 +12,14 @@ student_count_start: 1
 student_count_end: "{{ student_count }}"
 
 ## OpenShift Version to use, this will enable the correct repositories
-openshift_deploy_version: 3.6
+openshift_deploy_version: 3.7
 
 ## OpenShift Variables
 openshift_master_dns_prefix: "master"
 openshift_master_internal_dns_prefix: "master-internal"
 
 ## Domain to use for wildcard
-domain_name: rhte.sysdeseng.com
+domain_name: labs.sysdeseng.com
 
 ## AWS credentials (do not save it here, instead override with -e)
 aws_access_key: "{{ec2_access_key}}"

--- a/roles/tower_config/tasks/auth.yml
+++ b/roles/tower_config/tasks/auth.yml
@@ -1,11 +1,11 @@
 ---
 - name: Set Tower CLI Host
-  command: tower-cli config host "{{ tower_host }}"
+  command: tower-cli config host {{ tower_host }}
 
 - name: Set Tower CLI Username
-  command: tower-cli config username "{{ tower_username }}"
+  command: tower-cli config username {{ tower_username }}
 
 - name: Set Tower CLI Password
-  command: tower-cli config password "{{ tower_password }}"
+  command: tower-cli config password {{ tower_password }}
   no_log: True
 ...

--- a/roles/tower_config/tasks/inventory.yml
+++ b/roles/tower_config/tasks/inventory.yml
@@ -20,18 +20,6 @@
     tower_username: "{{ tower_username }}"
     tower_password: "{{ tower_password }}"
 
-- name: Configure Tower Inventory
-  tower_inventory:
-    tower_host: "{{ tower_host }}"
-    tower_username: "{{ tower_username }}"
-    tower_password: "{{ tower_password }}"
-    name: "{{ tower_inventory }}"
-    description: "{{ tower_inventory_description }}"
-    organization: "{{ tower_org }}"
-    variables:
-      - student_id: "{{ student_id }}"
-      - lab_user: "{{ lab_user }}"
-
 - include: inventory/groups.yml
   when: tower_inventory_group_config|bool == true
 ...

--- a/roles/tower_config/tasks/inventory/groups.yml
+++ b/roles/tower_config/tasks/inventory/groups.yml
@@ -64,11 +64,3 @@
   when: 
     - tower_openshift_masters_group_config|bool == true
     - tower_openshift_nodes_group_config|bool == true
-
-- name: Sync Inventory
-  command: >
-    tower-cli group sync
-      --name "{{ tower_inventory_group }}"
-      --wait
-      "{{ tower_cli_verbosity }}"
-  when: tower_inventory_sync|bool == true

--- a/roles/tower_config/tasks/job_templates/deploy_provision.yml
+++ b/roles/tower_config/tasks/job_templates/deploy_provision.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: Configure Job Template for Deploy-Provision
   tower_job_template:
     tower_host: "{{ tower_host }}"
@@ -13,6 +14,14 @@
     project: "{{ tower_project_provision_and_configure }}"
     playbook: "{{ tower_job_template_deploy_provision_playbook }}"
     machine_credential: "{{ tower_credential_machine }}"
+
+- name: Associate the AWS credential to the template
+  command: >
+    tower-cli job_template associate_credential
+      --job-template "{{ tower_job_template_deploy_provision }}"
+      --credential "{{ tower_credential_cloud }}"
+      --tower-username "{{ tower_username }}"
+      --tower-password "{{ tower_password }}"
 
 - name: Copy Job Template for Deploy-Provision Extra Variables file
   template:

--- a/roles/tower_config/tasks/prereqs.yml
+++ b/roles/tower_config/tasks/prereqs.yml
@@ -3,6 +3,7 @@
   command: >
     subscription-manager repos
       --enable="rhel-7-server-ose-{{ openshift_deploy_version }}-rpms"
+  ignore_errors: yes
   become: true
 
 - name: Install package requirements for Tower CLI
@@ -11,22 +12,13 @@
     state: present
   become: true
   with_items:
-    - python2-pip
+    - python2-ansible-tower-cli
     - git
     - pyOpenSSL
     - python-netaddr
     - python-six
-    - python2-boto3
     - python-click
     - python-httplib2
-
-- name: Install Tower CLI
-  pip:
-    name: "{{ item }}"
-  become: true
-  with_items:
-    - ansible-tower-cli
-    - boto
 
 - debug:
     var: "{{ item }}"

--- a/roles/tower_config/tasks/projects/install.yml
+++ b/roles/tower_config/tasks/projects/install.yml
@@ -16,14 +16,14 @@
   become: true
 
 - name: Add Tower Project for Install
-  tower_project:
-    name: "{{ tower_project_install }}"
-    description: "{{ tower_project_install_description }}"
-    organization: "{{ tower_org }}"
-    scm_type: "{{ tower_project_install_type }}"
-    local_path: "{{ tower_project_install_local_path }}"
-    state: present
-    tower_host: "{{ tower_host }}"
-    tower_username: "{{ tower_username }}"
-    tower_password: "{{ tower_password }}"
+  command: >
+    tower-cli project create 
+      --name "{{ tower_project_install }}" 
+      --tower-username "{{ tower_username }}" 
+      --tower-password "{{ tower_password }}" 
+      --local-path "{{ tower_project_install_local_path }}"
+      --tower-host "{{ tower_host }}"
+      --description "{{ tower_project_install_description }}" 
+      --organization "{{ tower_org }}" 
+      --scm-type "{{ tower_project_install_type }}" 
 ...

--- a/roles/tower_config/tasks/projects/provision_and_configure.yml
+++ b/roles/tower_config/tasks/projects/provision_and_configure.yml
@@ -1,23 +1,26 @@
 ---
 - name: Configure Project for Provision and Configure
-  tower_project:
-    tower_host: "{{ tower_host }}"
-    tower_username: "{{ tower_username }}"
-    tower_password: "{{ tower_password }}"
-    name: "{{ tower_project_provision_and_configure }}"
-    description: "{{ tower_project_provision_and_configure_description }}"
-    organization: "{{ tower_org }}"
-    state: present
-    scm_type: "{{ tower_project_provision_and_configure_type }}"
-    scm_url: "{{ tower_project_provision_and_configure_url }}"
-    scm_branch: "{{ tower_project_provision_and_configure_branch }}"
-    scm_clean: "{{ tower_project_provision_and_configure_clean }}"
-    scm_update_on_launch: "{{ tower_project_provision_and_configure_update_on_launch }}"
-    scm_delete_on_update: "{{ tower_project_provision_and_configure_delete_on_update }}"
+  command: >
+    tower-cli project create 
+      --name "{{ tower_project_provision_and_configure }}" 
+      --tower-username "{{ tower_username }}" 
+      --tower-password "{{ tower_password }}" 
+      --tower-host "{{ tower_host }}"
+      --description "{{ tower_project_provision_and_configure_description }}" 
+      --organization "{{ tower_org }}" 
+      --scm-type "{{ tower_project_provision_and_configure_type }}" 
+      --scm-url "{{ tower_project_provision_and_configure_url }}" 
+      --scm-branch "{{ tower_project_provision_and_configure_branch }}" 
+      --scm-clean "{{ tower_project_provision_and_configure_clean }}" 
+      --scm-update-on-launch "{{ tower_project_provision_and_configure_update_on_launch }}" 
+      --scm-delete-on-update "{{ tower_project_provision_and_configure_delete_on_update }}"
 
 - name: Update Project for Provision and Configure
   command: >
     tower-cli project update
+      --tower-username "{{ tower_username }}" 
+      --tower-password "{{ tower_password }}" 
+      --tower-host "{{ tower_host }}"
       --name "{{ tower_project_provision_and_configure }}"
       --wait
       "{{ tower_cli_verbosity }}"

--- a/roles/tower_config/tasks/user.yml
+++ b/roles/tower_config/tasks/user.yml
@@ -1,14 +1,14 @@
 ---
 - name: Add user to manage Tower
-  tower_user:
-    username: "{{ student_id }}"
-    password: "{{ tower_password }}"
-    email: "{{ student_id + '@example.org' }}"
-    state: present
-    superuser: true
-    tower_host: "{{ tower_host }}"
-    tower_username: "{{ tower_username }}"
-    tower_password: "{{ tower_password }}"
+  command: >
+    tower-cli user create 
+      --username "{{ student_id }}"
+      --password "{{ tower_password }}"
+      --email "{{ student_id + '@example.org' }}"
+      --is-superuser true
+      --tower-host "{{ tower_host }}"
+      --tower-username "{{ tower_username }}"
+      --tower-password "{{ tower_password }}"
 
 - set_fact:
     tower_username: "{{ student_id }}"

--- a/roles/tower_config/vars/full.yml
+++ b/roles/tower_config/vars/full.yml
@@ -3,8 +3,8 @@
 # NOTE: For the current run of labs the cli/machine/cloud credentials, prereqs and org are already in the AMI so are set to false here.
 tower_user_add: true
 tower_cli_credentials_config: true
-tower_prereqs_config: false
-tower_org_config: false
+tower_prereqs_config: true # scollier 1/4/2018
+tower_org_config: true # scollier 1/4/2018
 tower_credential_machine_config: false
 tower_credential_cloud_config: false
 tower_inventory_config: true


### PR DESCRIPTION


There were a few ansible module to tower-cli conversions.  Nothing changes when testing this. It will provision a tower host, configure it properly. The next thing to work on is proper deployment of OCP 3.7.