### PR TITLE
quick ansible role to validate that deploy-2-install job completed

### DIFF
--- a/aws_lab_launch.yml
+++ b/aws_lab_launch.yml
@@ -89,4 +89,7 @@
 
 - include: tower_config.yml
   when: tower_config is defined
+
+- include: validate-lab-deployment.yml
+  when: tower_config == "test"
 ...

--- a/roles/validate-lab-deployment/README.md
+++ b/roles/validate-lab-deployment/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/roles/validate-lab-deployment/defaults/main.yml
+++ b/roles/validate-lab-deployment/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for validate-lab-deployment

--- a/roles/validate-lab-deployment/handlers/main.yml
+++ b/roles/validate-lab-deployment/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for validate-lab-deployment

--- a/roles/validate-lab-deployment/meta/main.yml
+++ b/roles/validate-lab-deployment/meta/main.yml
@@ -1,0 +1,57 @@
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 1.2
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/roles/validate-lab-deployment/tasks/main.yml
+++ b/roles/validate-lab-deployment/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+# tasks file for validate-lab-deployment
+
+- name: Verify that the Deploy-2-Install job ran successfully.
+  command: >
+    tower-cli job status 7
+  register: job_results
+
+- debug:
+    var: job_results.stdout_lines
+  verbosity: 2
+
+#- name:
+#  fail:
+#    when:
+

--- a/roles/validate-lab-deployment/tests/inventory
+++ b/roles/validate-lab-deployment/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/validate-lab-deployment/tests/test.yml
+++ b/roles/validate-lab-deployment/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - validate-lab-deployment

--- a/roles/validate-lab-deployment/vars/main.yml
+++ b/roles/validate-lab-deployment/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for validate-lab-deployment

--- a/validate-lab-deployment.yml
+++ b/validate-lab-deployment.yml
@@ -1,0 +1,11 @@
+---
+- name: Validate the lab environment
+  hosts: tag_lab_role_tower,tower_instances
+  vars:
+    - ansible_ssh_user: ec2-user
+
+  vars_files:
+    - aws_vars.yml
+
+  roles:
+    - validate-lab-deployment


### PR DESCRIPTION
This PR is geared towards setting up a framework of validation scripts, written as ansible tasks.  Right now it's been proven out with a single task, but it could be extended easily to run a multitude of checks. 

There are 2 ways to check this new role:
1. Whenever the 'test' mode of deployment is run, the aws_lab_launch.yml playbook will call this and run whatever validation plays are in it.
2. It can be run externally and independently of any other plays or roles.  

To leverage #2 above you will need the ec2.py and a configured ec2.ini file to perform a dynamic inventory of the tower instances in AWS.  Once you have that, you can call the role like:

```
ansible-playbook -i /home/scollier/bin/ec2.py -e @scollier_secrets.yml validate-lab-deployment.yml
```

It will report:

```
ok: [52.57.231.244] => {
    "job_results.stdout_lines": [
        "========== ====== ======== ", 
        "  status   failed elapsed  ", 
        "========== ====== ======== ", 
        "successful  false 1046.805", 
        "========== ====== ======== "
    ]
}
```
For this job, the status will either be successful, as shown above, or failed, or running.


