### PR TITLE
Fix filter tasks and add admin password change

### DIFF
--- a/roles/tower_config/tasks/admin_password.yml
+++ b/roles/tower_config/tasks/admin_password.yml
@@ -1,0 +1,9 @@
+---
+- name: Set Tower 'admin' password to desired 'tower_password' value
+  expect:
+    command: tower-manage changepassword admin
+    responses: 
+      Password.*: "{{ tower_password }}"
+  become: true
+  no_log: True
+...

--- a/roles/tower_config/tasks/inventory.yml
+++ b/roles/tower_config/tasks/inventory.yml
@@ -20,6 +20,34 @@
     tower_username: "{{ tower_username }}"
     tower_password: "{{ tower_password }}"
 
+- name: Check for existing Tower Inventory Source
+  command: >
+    tower-cli inventory_source list
+      "{{ tower_cli_verbosity }}"
+      --format json
+  register: tower_inventory_source_list
+
+- set_fact:
+    tower_inventory_source_exists: true
+  when: tower_inventory_group_source in tower_inventory_source_list.stdout
+
+- name: Modify Tower Inventory Source
+  command: >
+    tower-cli inventory_source modify
+      --name "{{ tower_inventory_group_source }}"
+      --instance-filters "{{ tower_inventory_group_source_filters }}"
+      --update-on-launch {{ tower_inventory_group_source_update_on_launch }}
+      --credential {{ tower_credential_cloud }}
+      --source {{ tower_inventory_group_source }}
+      --description "{{ tower_inventory_group_source_description }}"
+      --inventory "{{ tower_inventory }}"
+      --overwrite {{ tower_inventory_group_source_overwrite }}
+      --source-regions {{ aws_region }}
+      --overwrite-vars {{ tower_inventory_group_source_overwrite_vars }}
+      --source-vars "{{ tower_inventory_group_source_vars | to_yaml }}"
+      "{{ tower_cli_verbosity }}"
+  when: tower_inventory_source_exists | default(False) | bool == True
+
 - name: Add Tower Inventory Source
   command: >
     tower-cli inventory_source create
@@ -35,6 +63,7 @@
       --overwrite-vars {{ tower_inventory_group_source_overwrite_vars }}
       --source-vars "{{ tower_inventory_group_source_vars | to_yaml }}"
       "{{ tower_cli_verbosity }}"
+  when: not tower_inventory_source_exists | default(False) | bool == True
 
 - include: inventory/groups.yml
   when: tower_inventory_group_config|bool == true

--- a/roles/tower_config/tasks/main.yml
+++ b/roles/tower_config/tasks/main.yml
@@ -11,6 +11,8 @@
 - include: prereqs.yml
   when: tower_prereqs_config|bool == true
 
+- include: admin_password.yml
+
 - include: auth.yml
   when: tower_cli_credentials_config|bool == true
 

--- a/roles/tower_config/tasks/prereqs.yml
+++ b/roles/tower_config/tasks/prereqs.yml
@@ -19,6 +19,13 @@
     - python-six
     - python-click
     - python-httplib2
+    - python2-pip
+
+- name: Pip install requirements for Tower CLI
+  pip:
+    name: pexpect
+    state: latest
+  become: true
 
 - debug:
     var: "{{ item }}"


### PR DESCRIPTION
Changes inventory_source task to first check if one exists, if so it will modify it to add the correct filter. Otherwise it creates it as before.

Also added admin password change to whatever `tower_password` is being set to. However, this requires `pexpect` version 3.3 or higher. The rpm in RHEL repos is 2.3, so using pip to install it for this role, since we already have EPEL. These tasks will be ported over to the AAB soon. To test, set `tower_prereqs_config: true` and specify `tower_password:`