### PR TITLE
Updates to Support OpenShift 3.9

### DIFF
--- a/aws_vars.yml
+++ b/aws_vars.yml
@@ -12,7 +12,7 @@ student_count_start: 1
 student_count_end: "{{ student_count }}"
 
 ## OpenShift Version to use, this will enable the correct repositories
-openshift_deploy_version: 3.7
+openshift_deploy_version: 3.9
 
 ## OpenShift Variables
 openshift_master_dns_prefix: "master"

--- a/roles/tower_config/defaults/main.yml
+++ b/roles/tower_config/defaults/main.yml
@@ -151,7 +151,7 @@ tower_job_template_scaleup_provision_extra_vars_path: "{{ tower_job_template_dep
 tower_job_template_scaleup_install: "Scaleup-2-Install"
 tower_job_template_scaleup_install_config: false
 tower_job_template_scaleup_install_description: "Scaleup Step 2 - Add instance as a node to existing OCP cluster"
-tower_job_template_scaleup_install_playbook: "ansible/openshift-ansible/playbooks/byo/openshift-node/scaleup.yml"
+tower_job_template_scaleup_install_playbook: "ansible/openshift-ansible/playbooks/openshift-node/scaleup.yml"
 tower_job_template_scaleup_install_become_enabled: "yes"
 
 # Job template for scaleup-configure

--- a/roles/tower_config/defaults/main.yml
+++ b/roles/tower_config/defaults/main.yml
@@ -119,15 +119,22 @@ tower_job_template_deploy_provision_description: "Deployment Step 1 - Creates AW
 tower_job_template_deploy_provision_playbook: "aws_create_hosts.yml"
 tower_job_template_deploy_provision_extra_vars_path: "tower_job_template_deploy_provision_extra_vars.yml.j2"
 
+# Tower job template for deployment-prerequisites
+tower_job_template_deploy_prerequisites: "Deploy-2-Prerequisites"
+tower_job_template_deploy_prerequisites_config: false
+tower_job_template_deploy_prerequisites_description: "Deployment Step 2 - Installs Prerequisites for OpenShift Container Platform"
+tower_job_template_deploy_prerequisites_playbook: "ansible/openshift-ansible/playbooks/prerequisites.yml"
+tower_job_template_deploy_prerequisites_become_enabled: "yes"
+
 # Tower job template for deployment-install
-tower_job_template_deploy_install: "Deploy-2-Install"
+tower_job_template_deploy_install: "Deploy-3-Install"
 tower_job_template_deploy_install_config: false
-tower_job_template_deploy_install_description: "Deployment Step 2 - Installs OpenShift Container Platform"
-tower_job_template_deploy_install_playbook: "ansible/openshift-ansible/playbooks/byo/config.yml"
+tower_job_template_deploy_install_description: "Deployment Step 3 - Installs OpenShift Container Platform"
+tower_job_template_deploy_install_playbook: "ansible/openshift-ansible/playbooks/deploy_cluster.yml"
 tower_job_template_deploy_install_become_enabled: "yes"
 
 # Job template for deployment-configure
-tower_job_template_deploy_configure: "Deploy-3-Post-Install"
+tower_job_template_deploy_configure: "Deploy-4-Post-Install"
 tower_job_template_deploy_configure_config: false
 tower_job_template_deploy_configure_description: "Deployment Step 3 - Post-install configuration"
 tower_job_template_deploy_configure_playbook: "openshift_postinstall.yml"

--- a/roles/tower_config/defaults/main.yml
+++ b/roles/tower_config/defaults/main.yml
@@ -84,7 +84,7 @@ tower_project_provision_and_configure_config: true
 tower_project_provision_and_configure_description: "Git repo with Ansible playbooks for provision (pre-install) and configure (post-install)"
 tower_project_provision_and_configure_type: "git"
 tower_project_provision_and_configure_url: "https://github.com/sabre1041/managing-ocp-install-beyond.git"
-tower_project_provision_and_configure_branch: "rhte"
+tower_project_provision_and_configure_branch: "ocp-3.9"
 tower_project_provision_and_configure_local_branch: ""
 tower_project_provision_and_configure_clean: "yes"
 tower_project_provision_and_configure_update_on_launch: "no"

--- a/roles/tower_config/defaults/main.yml
+++ b/roles/tower_config/defaults/main.yml
@@ -84,7 +84,7 @@ tower_project_provision_and_configure_config: true
 tower_project_provision_and_configure_description: "Git repo with Ansible playbooks for provision (pre-install) and configure (post-install)"
 tower_project_provision_and_configure_type: "git"
 tower_project_provision_and_configure_url: "https://github.com/sabre1041/managing-ocp-install-beyond.git"
-tower_project_provision_and_configure_branch: "ocp-3.9"
+tower_project_provision_and_configure_branch: "summit2018"
 tower_project_provision_and_configure_local_branch: ""
 tower_project_provision_and_configure_clean: "yes"
 tower_project_provision_and_configure_update_on_launch: "no"

--- a/roles/tower_config/defaults/main.yml
+++ b/roles/tower_config/defaults/main.yml
@@ -130,7 +130,7 @@ tower_job_template_deploy_prerequisites_become_enabled: "yes"
 tower_job_template_deploy_install: "Deploy-3-Install"
 tower_job_template_deploy_install_config: false
 tower_job_template_deploy_install_description: "Deployment Step 3 - Installs OpenShift Container Platform"
-tower_job_template_deploy_install_playbook: "ansible/openshift-ansible/playbooks/deploy_cluster.yml"
+tower_job_template_deploy_install_playbook: "ansible/openshift-ansible/playbooks/deploy_cluster_wrapper.yml"
 tower_job_template_deploy_install_become_enabled: "yes"
 
 # Job template for deployment-configure

--- a/roles/tower_config/files/deploy_cluster_wrapper.yml
+++ b/roles/tower_config/files/deploy_cluster_wrapper.yml
@@ -1,0 +1,8 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Deploy Cluster Wrapper
+      debug:
+        msg: "Deploying OpenShift Cluster"
+
+- import_playbook: deploy_cluster.yml

--- a/roles/tower_config/tasks/job_templates.yml
+++ b/roles/tower_config/tasks/job_templates.yml
@@ -3,6 +3,8 @@
   when: tower_job_template_self_configure_config|bool == true
 - include: job_templates/deploy_provision.yml
   when: tower_job_template_deploy_provision_config|bool == true
+- include: job_templates/deploy_prerequisites.yml
+  when: tower_job_template_deploy_prerequisites_config|bool == true
 - include: job_templates/deploy_install.yml
   when: tower_job_template_deploy_install_config|bool == true
 - include: job_templates/deploy_configure.yml

--- a/roles/tower_config/tasks/job_templates/deploy_prerequisites.yml
+++ b/roles/tower_config/tasks/job_templates/deploy_prerequisites.yml
@@ -1,5 +1,5 @@
 ---
-- name: Configure Job Template for Deploy-Install
+- name: Configure Job Template for Deploy-Prequisites
   tower_job_template:
     tower_host: "{{ tower_host }}"
     tower_username: "{{ tower_username }}"

--- a/roles/tower_config/tasks/job_templates/deploy_prerequisites.yml
+++ b/roles/tower_config/tasks/job_templates/deploy_prerequisites.yml
@@ -1,0 +1,25 @@
+---
+- name: Configure Job Template for Deploy-Install
+  tower_job_template:
+    tower_host: "{{ tower_host }}"
+    tower_username: "{{ tower_username }}"
+    tower_password: "{{ tower_password }}"
+    job_type: run
+    name: "{{ tower_job_template_deploy_prerequisites }}"
+    description: "{{ tower_job_template_deploy_prerequisites_description }}"
+    state: present
+    inventory: "{{ tower_inventory }}"
+    project: "{{ tower_project_install }}"
+    playbook: "{{ tower_job_template_deploy_prerequisites_playbook }}"
+    become_enabled: "{{ tower_job_template_deploy_prerequisites_become_enabled }}"
+    machine_credential: "{{ tower_credential_machine }}"
+    cloud_credential: "{{ tower_credential_cloud }}"
+
+- name: Associate the AWS credential to the template
+  command: >
+    tower-cli job_template associate_credential
+      --job-template "{{ tower_job_template_deploy_prerequisites }}"
+      --credential "{{ tower_credential_cloud }}"
+      --tower-username "{{ tower_username }}"
+      --tower-password "{{ tower_password }}"
+...

--- a/roles/tower_config/tasks/job_templates/self_configure.yml
+++ b/roles/tower_config/tasks/job_templates/self_configure.yml
@@ -27,12 +27,4 @@
       --name="{{ tower_job_template_self_configure }}"
       --extra-vars="@/tmp/{{ tower_job_template_self_configure_extra_vars_path }}"
       "{{ tower_cli_verbosity }}"
-
-- name: Copy Deploy Cluster Wrapper Playbook
-  become: true
-  file:
-    src: deploy_cluster_wrapper.yml
-    dest: "{{ tower_projects_root }}/{{ tower_job_template_deploy_install_playbook }}"
-    owner: root
-    group: root
 ...

--- a/roles/tower_config/tasks/job_templates/self_configure.yml
+++ b/roles/tower_config/tasks/job_templates/self_configure.yml
@@ -27,4 +27,12 @@
       --name="{{ tower_job_template_self_configure }}"
       --extra-vars="@/tmp/{{ tower_job_template_self_configure_extra_vars_path }}"
       "{{ tower_cli_verbosity }}"
+
+- name: Copy Deploy Cluster Wrapper Playbook
+  become: true
+  file:
+    src: deploy_cluster_wrapper.yml
+    dest: "{{ tower_projects_root }}/{{ tower_job_template_deploy_install_playbook }}"
+    owner: root
+    group: root
 ...

--- a/roles/tower_config/tasks/projects/install.yml
+++ b/roles/tower_config/tasks/projects/install.yml
@@ -15,6 +15,14 @@
     state: link
   become: true
 
+- name: Copy Deploy Cluster Wrapper Playbook
+  become: true
+  copy:
+    src: deploy_cluster_wrapper.yml
+    dest: "{{ tower_projects_root }}/{{ tower_job_template_deploy_install_playbook }}"
+    owner: root
+    group: root
+
 - name: Add Tower Project for Install
   command: >
     tower-cli project create 

--- a/roles/tower_config/tasks/projects/install.yml
+++ b/roles/tower_config/tasks/projects/install.yml
@@ -19,7 +19,7 @@
   become: true
   copy:
     src: deploy_cluster_wrapper.yml
-    dest: "{{ tower_projects_root }}/{{ tower_job_template_deploy_install_playbook }}"
+    dest: "{{ tower_projects_root }}/share/{{ tower_job_template_deploy_install_playbook }}"
     owner: root
     group: root
 

--- a/roles/tower_config/templates/OSEv3.yml.j2
+++ b/roles/tower_config/templates/OSEv3.yml.j2
@@ -1,8 +1,6 @@
 ---
 deployment_type: openshift-enterprise
 osm_use_cockpit: no
-openshift_master_api_port: 443
-openshift_master_console_port: 443
 openshift_master_default_subdomain: apps-{{ student_id }}.{{ domain_name }}
 openshift_master_identity_providers:
 - name: htpasswd_auth

--- a/roles/tower_config/templates/OSEv3.yml.j2
+++ b/roles/tower_config/templates/OSEv3.yml.j2
@@ -1,6 +1,8 @@
 ---
 deployment_type: openshift-enterprise
 osm_use_cockpit: no
+openshift_master_api_port=443
+openshift_master_console_port=443
 openshift_master_default_subdomain: apps-{{ student_id }}.{{ domain_name }}
 openshift_master_identity_providers:
 - name: htpasswd_auth
@@ -9,7 +11,7 @@ openshift_master_identity_providers:
   kind: HTPasswdPasswordIdentityProvider
   filename: /etc/origin/master/htpasswd
 openshift_master_htpasswd_users:
-  {{ student_id }}: $apr1$dxclpIY6$IDo1jwwuu4/6DPL0TNaUw.
+  {{ student_id }}: $apr1$yv51mDpN$bIpurV4keQTUVt8KaXOu.0
 openshift_master_image_policy_config:
   maxImagesBulkImportedPerRepository: 100
 openshift_hosted_metrics_deploy: yes
@@ -24,8 +26,12 @@ openshift_cloudprovider_kind: aws
 openshift_master_cluster_hostname: "{{ openshift_master_internal_dns_prefix }}-{{ student_id }}.{{ domain_name }}"
 openshift_master_cluster_public_hostname: "{{ openshift_master_dns_prefix }}-{{ student_id }}.{{ domain_name }}"
 openshift_metrics_cassandra_storage_type: dynamic
-openshift_disable_check: memory_availability
-openshift_enable_service_catalog: true
+openshift_disable_check: memory_availability,disk_availability
+template_service_broker_selector:
+  type: infra
+openshift_hosted_prometheus_deploy: true
+openshift_prometheus_node_selector:
+  type: infra
 {% raw %}
 openshift_cloudprovider_aws_access_key: "{{ lookup('env','AWS_ACCESS_KEY_ID') }}"
 openshift_cloudprovider_aws_secret_key: "{{ lookup('env','AWS_SECRET_ACCESS_KEY') }}"

--- a/roles/tower_config/templates/OSEv3.yml.j2
+++ b/roles/tower_config/templates/OSEv3.yml.j2
@@ -12,8 +12,7 @@ openshift_master_htpasswd_users:
   {{ student_id }}: $apr1$yv51mDpN$bIpurV4keQTUVt8KaXOu.0
 openshift_master_image_policy_config:
   maxImagesBulkImportedPerRepository: 100
-openshift_hosted_metrics_deploy: yes
-openshift_hosted_metrics_storage_kind: dynamic
+openshift_metrics_install_metrics: yes
 os_sdn_network_plugin_name: redhat/openshift-ovs-multitenant
 osn_storage_plugin_deps: []
 openshift_schedulable: True
@@ -34,6 +33,7 @@ openshift_prometheus_node_selector:
 openshift_cloudprovider_aws_access_key: "{{ lookup('env','AWS_ACCESS_KEY_ID') }}"
 openshift_cloudprovider_aws_secret_key: "{{ lookup('env','AWS_SECRET_ACCESS_KEY') }}"
 openshift_node_labels: "{{ ec2_tag_node_labels }}"
+openshift_prometheus_node_exporter_image_version: "{{ openshift_image_tag }}"
 {% endraw %}
 
 # Default Node Selector Cannot be Used Due to Issue With Service Catalog Deployment. Is set during Postinstall playbook

--- a/roles/tower_config/templates/OSEv3.yml.j2
+++ b/roles/tower_config/templates/OSEv3.yml.j2
@@ -1,8 +1,8 @@
 ---
 deployment_type: openshift-enterprise
 osm_use_cockpit: no
-openshift_master_api_port=443
-openshift_master_console_port=443
+openshift_master_api_port: 443
+openshift_master_console_port: 443
 openshift_master_default_subdomain: apps-{{ student_id }}.{{ domain_name }}
 openshift_master_identity_providers:
 - name: htpasswd_auth

--- a/roles/tower_config/templates/tower_job_template_self_configure_extra_vars.yml.j2
+++ b/roles/tower_config/templates/tower_job_template_self_configure_extra_vars.yml.j2
@@ -15,6 +15,7 @@ tower_project_install_config: true
 tower_openshift_new_nodes_group_config: true
 tower_job_template_self_configure_config: false
 tower_job_template_deploy_provision_config: true
+tower_job_template_deploy_prerequisites_config: true
 tower_job_template_deploy_install_config: true
 tower_job_template_deploy_configure_config: true
 tower_job_template_scaleup_provision_config: true

--- a/roles/tower_config/templates/tower_workflow_template_deploy_schema.yml
+++ b/roles/tower_config/templates/tower_workflow_template_deploy_schema.yml
@@ -1,6 +1,8 @@
 ---
 - job_template: "{{ tower_job_template_deploy_provision }}"
   success_nodes:
-  - job_template: "{{ tower_job_template_deploy_install }}"
+  - job_template: "{{ tower_job_template_deploy_prerequisites }}"
     success_nodes:
-    - job_template: "{{ tower_job_template_deploy_configure }}"
+    - job_template: "{{ tower_job_template_deploy_install }}"
+      success_nodes:
+      - job_template: "{{ tower_job_template_deploy_configure }}"

--- a/roles/tower_config/vars/full.yml
+++ b/roles/tower_config/vars/full.yml
@@ -18,6 +18,7 @@ tower_project_provision_and_configure_config: true
 tower_project_install_config: true
 tower_job_template_self_configure_config: false
 tower_job_template_deploy_provision_config: true
+tower_job_template_deploy_prerequisites_config: true
 tower_job_template_deploy_install_config: true
 tower_job_template_deploy_configure_config: true
 tower_job_template_scaleup_provision_config: true

--- a/roles/tower_config/vars/none.yml
+++ b/roles/tower_config/vars/none.yml
@@ -16,6 +16,7 @@ tower_project_provision_and_configure_config: false
 tower_project_install_config: false
 tower_job_template_self_configure_config: false
 tower_job_template_deploy_provision_config: false
+tower_job_template_deploy_prerequisites_config: false
 tower_job_template_deploy_install_config: false
 tower_job_template_deploy_configure_config: false
 tower_job_template_scaleup_provision_config: false

--- a/roles/tower_config/vars/self.yml
+++ b/roles/tower_config/vars/self.yml
@@ -17,6 +17,7 @@ tower_project_provision_and_configure_config: true
 tower_project_install_config: false
 tower_job_template_self_configure_config: true
 tower_job_template_deploy_provision_config: false
+tower_job_template_deploy_prerequisites_config: false
 tower_job_template_deploy_install_config: false
 tower_job_template_deploy_configure_config: false
 tower_job_template_scaleup_provision_config: false

--- a/roles/tower_config/vars/self.yml
+++ b/roles/tower_config/vars/self.yml
@@ -2,7 +2,7 @@
 # Self-configure configure a bare-minimum Tower with a project and a job template to run this role with a full config
 tower_user_add: true
 tower_cli_credentials_config: true
-tower_prereqs_config: false
+tower_prereqs_config: true
 tower_org_config: false
 tower_credential_machine_config: false
 tower_credential_cloud_config: false

--- a/roles/tower_config/vars/test.yml
+++ b/roles/tower_config/vars/test.yml
@@ -18,6 +18,7 @@ tower_project_provision_and_configure_config: true
 tower_project_install_config: true
 tower_job_template_self_configure_config: true
 tower_job_template_deploy_provision_config: true
+tower_job_template_deploy_prerequisites_config: true
 tower_job_template_deploy_install_config: true
 tower_job_template_deploy_configure_config: true
 tower_job_template_scaleup_provision_config: true


### PR DESCRIPTION
How to test this PR:

1. Deploy the lab by running the `aws_lab_launch.yml` playboook
2. Correct the Project to reference the PR branch
    1. Select Projects -> Click _edit_ button next to "Managing OCP from Install and Beyond"
    2. Change repository and branch to the following
        * Repository: https://github.com/sabre1041/managing-ocp-install-beyond
        * Branch: 3.9-updates
    3. Check "Delete on Update"
    4. Click Save
3. Execute the `Self Configure` Job Template
4. Enable `local_action` to escalate to sudo (Does not need to be completed once new AMI is spun)
    1. Add the following to the `/etc/tower/settings.py` file
    ```
    AWX_PROOT_ENABLED=False
    ```
    2. Restart Tower
    ```
    AWX_PROOT_ENABLED=False
    ```
    3. Add the `awx` user to sudo up without a password by uncommenting the following line using `visudo`
    ```
    %wheel  ALL=(ALL)       NOPASSWD: ALL
    ```
    4. Add the `awx` user to the `wheel` group
    ```
    usermod -aG wheel awx
    ```
    5. Restart the entire tower VM
5. Launch the _1-Deploy_OpenShift_on_AWS_ job template and OpenShift 3.9 will be deployed