### PR TITLE
Support for dynamic scaleup

### DIFF
--- a/aws_add_node.yml
+++ b/aws_add_node.yml
@@ -20,7 +20,8 @@
         region: "{{ aws_region }}"
         state: present
         user_data: "{{ lookup('template', 'aws_user_data.j2') }}"
-      with_items: "{{ aws_scaleup_instances }}"
+      with_items: "{{ aws_instances }}"
+      when: item.meta.node_type == 'node' or item.meta.node_type == 'new_node'
       register: instances_created
   
     - add_host:
@@ -30,6 +31,7 @@
         public_ip: "{{ item.instances.0.public_ip }}"
         groups: OSEv3
         student_id: "{{ item.instances.0.tags.student_id }}"
+      when: item['instances'] is defined
       with_items: "{{ instances_created.results }}"
 
     - debug:
@@ -41,6 +43,7 @@
         port: 22
         host: "{{ item.instances.0.public_ip }}"
         timeout: 1000
+      when: item['instances'] is defined
       with_items: "{{ instances_created.results }}"
 
     - name: Register Host DNS
@@ -50,17 +53,18 @@
         type: A
         overwrite: True
         ttl: 60
-        record: "{{ aws_scaleup_instances[item.0].name }}-{{ student_id }}.{{ domain_name }}"
-        value: "{{ instances_created.results[item.0]['instances'][0]['public_ip'] }}"
+        record: "{{ item['instances'][0]['tags']['Name'] }}"
+        value: "{{ item['instances'][0]['public_ip'] }}"
         wait: yes
-      register: host_dns_entries
-      with_indexed_items: "{{ aws_scaleup_instances }}"
+      when: item['instances'] is defined
+      with_items: "{{ instances_created.results }}"
 
     - name: Wait for resolvable route53 hostname
-      local_action: command host {{ aws_scaleup_instances[item.0].name }}-{{ student_id }}.{{ domain_name }}
+      local_action: command host {{ item['instances'][0]['tags']['Name'] }}
       register: host_result
       until: host_result.rc == 0
       retries: 60
       delay: 5
-      with_indexed_items: "{{ aws_scaleup_instances }}"
+      when: item['instances'] is defined
+      with_items: "{{ instances_created.results }}"
 ...

--- a/aws_create_hosts.yml
+++ b/aws_create_hosts.yml
@@ -51,11 +51,11 @@
         type: A
         overwrite: True
         ttl: 60
-        record: "{{ aws_instances[item.0].name }}-{{ student_id }}.{{ domain_name }}"
-        value: "{{ instances_created.results[item.0]['instances'][0]['public_ip'] }}"
+        record: "{{ item['instances'][0]['tags']['Name'] }}"
+        value: "{{ item['instances'][0]['public_ip'] }}"
         wait: yes
       register: host_dns_entries
-      with_indexed_items: "{{ aws_instances }}"
+      with_items: "{{ instances_created.results }}"
 
     - name: Register Public Environment DNS
       route53:
@@ -86,10 +86,10 @@
       when: "'node_type' in item.0['meta'] and 'master' in item.0['meta']['node_type']"
 
     - name: Wait for resolvable route53 hostname
-      local_action: command host {{ aws_instances[item.0].name }}-{{ student_id }}.{{ domain_name }}
+      local_action: command host {{ item['instances'][0]['tags']['Name'] }}
       register: host_result
       until: host_result.rc == 0
       retries: 60
       delay: 5
-      with_indexed_items: "{{ aws_instances }}"
+      with_items: "{{ instances_created.results }}"
 ...

--- a/aws_vars.yml
+++ b/aws_vars.yml
@@ -71,24 +71,11 @@ aws_instances:
     - etcd
     - osev3
     - creator_"{{ lab_user }}"
-- name: node1
+- name: node-{{ lookup('password', '/dev/null length=5 chars=ascii_letters') | lower }}
   type: "{{ ocp_node_inst_type }}"
   image: "{{ ocp_ami_id }}"
   meta:
-    node_type: 'node'
-    node_labels:
-      type: app
-      zone: default
-  groups:
-    - nodes
-    - osev3
-    - creator_"{{ lab_user }}"
-aws_scaleup_instances:
-- name: node2
-  type: "{{ ocp_node_inst_type }}"
-  image: "{{ ocp_ami_id }}"
-  meta:
-    node_type: 'new_node'
+    node_type: "{{ (aws_ocp_method is defined and aws_ocp_method == 'scaleup') | ternary('new_node','node') }}"
     node_labels:
       type: app
       zone: default

--- a/openshift_scaleup_postinstall.yml
+++ b/openshift_scaleup_postinstall.yml
@@ -1,0 +1,44 @@
+---
+
+- hosts: localhost
+  vars_files:
+    - aws_vars.yml
+    - "roles/tower_config/defaults/main.yml"
+  tasks:
+    - set_fact:
+        tower_host: "localhost"
+
+    - name: Query AWS Instances
+      ec2_instance_facts:
+        region: "{{ aws_region }}"
+        filters:
+          instance-state-name: running
+          "tag:lab_role": "new_node"
+          "tag:student_id": "{{ student_id }}"
+      register: ec2_tags
+
+    - name: Tag Instance As a Normal Node
+      ec2_tag:
+        region: "{{ aws_region }}"
+        resource: "{{ item['instance_id'] }}"
+        tags:
+          lab_role: node
+      with_items: "{{ ec2_tags.instances }}"
+
+    - import_tasks: "roles/tower_config/tasks/auth.yml"
+
+    - name: Disassocaite Host From Tower Inventory
+      command: >
+        tower-cli host disassociate
+          --group "{{ item[1] }}"
+          --host {{ item[0].tags['Name'] }}
+      with_nested:
+        - "{{ ec2_tags.instances }}"
+        - [ '{{ tower_new_node_tag }}', '{{ tower_openshift_new_nodes_group }}' ]
+
+
+    - name: Update Tower Inventory
+      command: >
+        tower-cli inventory batch_update
+          --name {{ tower_inventory }}
+      when: ec2_tags.instances | length > 0

--- a/roles/tower_config/defaults/main.yml
+++ b/roles/tower_config/defaults/main.yml
@@ -145,7 +145,7 @@ tower_job_template_scaleup_provision: "Scaleup-1-Provision"
 tower_job_template_scaleup_provision_config: false
 tower_job_template_scaleup_provision_description: "Scaleup Step 1 - Creates AWS instance to be added to the existing OCP cluster"
 tower_job_template_scaleup_provision_playbook: "aws_add_node.yml"
-tower_job_template_scaleup_provision_extra_vars_path: "{{ tower_job_template_deploy_provision_extra_vars_path }}"
+tower_job_template_scaleup_provision_extra_vars_path: "tower_job_template_scaleup_provision_extra_vars.yml.j2"
 
 # Tower job template for scaleup-install
 tower_job_template_scaleup_install: "Scaleup-2-Install"
@@ -158,8 +158,9 @@ tower_job_template_scaleup_install_become_enabled: "yes"
 tower_job_template_scaleup_configure: "Scaleup-3-Post-Install"
 tower_job_template_scaleup_configure_config: false
 tower_job_template_scaleup_configure_description: "Scaleup Step 3 Post-Install configuration"
-tower_job_template_scaleup_configure_playbook: "openshift_postinstall.yml"
-tower_job_template_scaleup_configure_become_enabled: "yes"
+tower_job_template_scaleup_configure_playbook: "openshift_scaleup_postinstall.yml"
+tower_job_template_scaleup_configure_extra_vars_path: "tower_job_template_scaleup_postinstall_extra_vars.yml.j2"
+
 
 # Tower job template for terminate-ocp
 tower_job_template_terminate_ocp: "Terminate-OCP"

--- a/roles/tower_config/tasks/job_templates/scaleup_configure.yml
+++ b/roles/tower_config/tasks/job_templates/scaleup_configure.yml
@@ -13,4 +13,24 @@
     project: "{{ tower_project_provision_and_configure }}"
     playbook: "{{ tower_job_template_scaleup_configure_playbook }}"
     machine_credential: "{{ tower_credential_machine }}"
+
+- name: Associate the AWS credential to the template
+  command: >
+    tower-cli job_template associate_credential
+      --job-template "{{ tower_job_template_scaleup_configure }}"
+      --credential "{{ tower_credential_cloud }}"
+      --tower-username "{{ tower_username }}"
+      --tower-password "{{ tower_password }}"
+
+- name: Copy Job Template for Scaleup-Provision Extra Variables file
+  template:
+    src: "{{ tower_job_template_scaleup_configure_extra_vars_path }}"
+    dest: "/tmp/{{ tower_job_template_scaleup_configure_extra_vars_path }}"
+
+- name: Update Job Template for Scaleup-Provision with Extra Vars
+  command: >
+    tower-cli job_template modify
+      --name="{{ tower_job_template_scaleup_configure }}"
+      --extra-vars="@/tmp/{{ tower_job_template_scaleup_configure_extra_vars_path }}"
+      "{{ tower_cli_verbosity }}"
 ...

--- a/roles/tower_config/templates/tower_job_template_scaleup_postinstall_extra_vars.yml.j2
+++ b/roles/tower_config/templates/tower_job_template_scaleup_postinstall_extra_vars.yml.j2
@@ -1,0 +1,4 @@
+---
+aws_region: "{{ aws_region }}"
+student_id: "{{ student_id }}"
+tower_password: "{{ tower_password }}"

--- a/roles/tower_config/templates/tower_job_template_scaleup_provision_extra_vars.yml.j2
+++ b/roles/tower_config/templates/tower_job_template_scaleup_provision_extra_vars.yml.j2
@@ -1,0 +1,18 @@
+---
+student_id: "{{ student_id }}"
+lab_user: "{{ lab_user }}"
+aws_subnet_id: "{{ aws_subnet_id }}"
+aws_region: "{{ aws_region }}"
+aws_az_1: "{{ aws_az_1 }}"
+aws_sec_group: "{{ aws_sec_group }}"
+aws_key_name: "{{ aws_key_name }}"
+aws_vpc_name: "{{ aws_vpc_name }}"
+aws_vpc_cidr_block: "{{ aws_vpc_cidr_block }}"
+aws_subnet_cidr: "{{ aws_subnet_cidr }}"
+aws_subnet_name: "{{ aws_subnet_name }}"
+aws_route_table: "{{ aws_route_table }}"
+domain_name: "{{ domain_name }}"
+ocp_ami_id: "{{ ocp_ami_id }}"
+ocp_master_inst_type: "{{ ocp_master_inst_type }}"
+ocp_node_inst_type: "{{ ocp_node_inst_type }}"
+aws_ocp_method: scaleup


### PR DESCRIPTION
Added support for dynamically scaling up beyond 2 total dedicated nodes.

* Nodes now have a random 5 characters id value
* Support for managing tag names and Ansible Tower inventory

_Note_: This has yet to be tested E2E. PR being submitted to get eyes on it and for those interested to test it out. YMMV!