### PR TITLE
Add tower ec2 variables and remove private key default filename

### DIFF
--- a/aws_vars.yml
+++ b/aws_vars.yml
@@ -22,8 +22,12 @@ openshift_master_internal_dns_prefix: "master-internal"
 domain_name: labs.sysdeseng.com
 
 ## AWS credentials (do not save it here, instead override with -e)
-aws_access_key: "{{ec2_access_key}}"
-aws_secret_key: "{{ec2_secret_key}}"
+aws_access_key: "{{ ec2_access_key }}"
+aws_secret_key: "{{ ec2_secret_key }}"
+
+## AWS credentials Tower (do not save it here, instead override with -e)
+tower_ec2_access_key: "{{ tower_ec2_access_key }}"
+tower_ec2_secret_key: "{{ tower_ec2_secret_key }}"
 
 ## Set the AMI IDs here (or override with -e). Some commonly used AMIs are defined here, but ultimately the ones that matter are 'tower_ami_id' and 'ocp_ami_id'
 ## Tower AMI ID - This is the only variable used in the Playbooks, set it to one of the above (or override with -e)

--- a/roles/tower_config/defaults/main.yml
+++ b/roles/tower_config/defaults/main.yml
@@ -41,7 +41,7 @@ tower_credential_machine: "SSH"
 tower_credential_machine_config: false
 tower_credential_machine_description: "Private SSH Key"
 tower_credential_machine_type: "Machine"
-tower_credential_machine_ssh_key_data_file: "specify_your_private_key_filename_here.pem"
+tower_credential_machine_ssh_key_data_file: "{{ tower_credential_machine_ssh_key_data_file }}"
 tower_credential_machine_username: "ec2-user"
 
 # Tower cloud credential
@@ -49,8 +49,8 @@ tower_credential_cloud: "AWS"
 tower_credential_cloud_config: false
 tower_credential_cloud_description: "AWS Access and Secret"
 tower_credential_cloud_type: "Amazon Web Services"
-tower_credential_cloud_username: "{{ec2_access_key}}"
-tower_credential_cloud_password: "{{ec2_secret_key}}"
+tower_credential_cloud_username: "{{ tower_ec2_access_key }}"
+tower_credential_cloud_password: "{{ tower_ec2_secret_key }}"
 
 # Tower inventory
 tower_inventory: "OpenShift"

--- a/roles/tower_config/defaults/main.yml
+++ b/roles/tower_config/defaults/main.yml
@@ -41,6 +41,7 @@ tower_credential_machine: "SSH"
 tower_credential_machine_config: false
 tower_credential_machine_description: "Private SSH Key"
 tower_credential_machine_type: "Machine"
+# The following should be a private SSH key in the same local directory that the playbook is run. A future refactor should allow absolute filenames instead. Specify this value in your secrets file.
 tower_credential_machine_ssh_key_data_file: "{{ tower_credential_machine_ssh_key_data_file }}"
 tower_credential_machine_username: "ec2-user"
 


### PR DESCRIPTION
* Specify variable 'tower_credential_machine_ssh_key_data_file' in secrets
* Specify variables 'tower_ec2_access_key' and 'tower_ec2_secret_key'