### PR TITLE
Full Prometheus Support

### DIFF
--- a/openshift_postinstall.yml
+++ b/openshift_postinstall.yml
@@ -4,12 +4,13 @@
     templates_query: '{range .items[*]}{.metadata.name}{"\n"}{end}'
     image_streams_query: '{range .items[*]}{.metadata.name}{"\n"}{end}'
     templates_to_keep: ['cakephp-mysql-persistent', 'metrics-deployer-template', 'registry-console']
-    image_streams_to_keep: ['php', 'mysql']
+    image_streams_to_keep: ['python']
     service_catalog_projects_to_annotate: ['kube-service-catalog']
     default_node_selector: 'type=app'
     service_catalog_default_node_selector: 'openshift-infra=apiserver'
     web_console_namespace: openshift-web-console
     tmp_configmap_prometheus: /tmp/prometheus-configmap.yml
+    tmp_configmap_alertmanager: /tmp/alertmanager-configmap.yml
     cfme_template: https://raw.githubusercontent.com/openshift/openshift-ansible/release-3.7/roles/openshift_examples/files/examples/v3.7/cfme-templates/cfme-template.yaml
   tasks:
   - name: Get templates
@@ -69,10 +70,10 @@
     shell: oc export configmap/prometheus -n {{ openshift_prometheus_namespace }} > {{ tmp_configmap_prometheus }}
 
   - name: Update Prometheus ConfigMap File
-    lineinfile:
-      insertbefore: "^    alerting:"
-      line: "    # OpenShift Router\n    - job_name: openshift-routers\n      scrape_interval: 30s\n      scrape_timeout: 30s\n      metrics_path: /metrics\n      scheme: http\n      static_configs:\n      - targets:\n        - router.default.svc.cluster.local:1936\n      basic_auth:\n        username: admin\n        password: {{ router_password.stdout }}\n"
-      dest: "{{ tmp_configmap_prometheus }}"
+    replace:
+      regexp: "^    alerting:$"
+      replace: "    # OpenShift Router\n    - job_name: openshift-routers\n      scrape_interval: 30s\n      scrape_timeout: 30s\n      metrics_path: /metrics\n      scheme: http\n      static_configs:\n      - targets:\n        - router.default.svc.cluster.local:1936\n      basic_auth:\n        username: admin\n        password: {{ router_password.stdout }}\n    alerting: #"
+      path: "{{ tmp_configmap_prometheus }}"
 
   - name: Update Prometheus ConfigMap
     command: >
@@ -82,6 +83,24 @@
     file:
       path: "{{ tmp_configmap_prometheus }}"
       state: absent
+  
+  - name: AlertManager Template
+    template:
+      src: templates/alertmanager.j2
+      dest: "{{ tmp_configmap_alertmanager }}"
+
+  - name: Delete Prometheus ConfigMap
+    command: >
+      oc delete configmap -n {{ openshift_prometheus_namespace }} alertmanager
+
+  - name: Update AlertManager ConfigMap
+    command: >
+      oc create configmap alertmanager -n {{ openshift_prometheus_namespace }} --from-file=alertmanager.yml={{ tmp_configmap_alertmanager }}
+  
+  - name: Remove AlertManager ConfigMap File
+    file:
+      state: absent
+      path: "{{ tmp_configmap_alertmanager }}"
 
   - name: Remove Prometheus Scrape Annotation
     shell: oc annotate svc router -n default prometheus.io/scrape=false --overwrite
@@ -119,3 +138,4 @@
     command: >
       oc delete pods --all -n {{ item}}
     with_items: "{{ service_catalog_projects_to_annotate }}"
+  

--- a/roles/tower_config/defaults/main.yml
+++ b/roles/tower_config/defaults/main.yml
@@ -242,4 +242,7 @@ tower_workflow_job_terminate_launch: false
 tower_workflow_job_terminate_launch_async: 360
 # Workflow job polling
 tower_workflow_job_terminate_launch_poll: 0
+
+tower_openshift_config_dir: "/var/lib/aws/openshift"
+tower_openshift_prometheus_config_dir: "{{ tower_openshift_config_dir }}/prometheus"
 ...

--- a/roles/tower_config/files/prometheus_additional_rule.yml
+++ b/roles/tower_config/files/prometheus_additional_rule.yml
@@ -1,0 +1,13 @@
+groups:
+- name: managing-ocp-cluster-rules
+  interval: 30s # defaults to global interval
+  rules:
+    - alert: Minimum Number of Application Nodes
+      expr: sum(up{type="app",job="kubernetes-nodes"}) < 0
+      for: 2m
+      labels:
+        severity: critical
+        type: ansible-target
+      annotations:
+        description: The Number of Application Nodes is Below Minimum Threshold
+        summary: Minimum Application Nodes

--- a/roles/tower_config/tasks/main.yml
+++ b/roles/tower_config/tasks/main.yml
@@ -43,6 +43,9 @@
 - import_tasks: workflows.yml
   tags: workflows
 
+- import_tasks: openshift_configs.yml
+  tags: openshift_configs
+
 - import_tasks: deauth.yml
   when: not tower_cli_credentials_keep|bool == true
   tags: deauth

--- a/roles/tower_config/tasks/openshift_configs.yml
+++ b/roles/tower_config/tasks/openshift_configs.yml
@@ -1,0 +1,24 @@
+- name: Create Directory for OpenShift Configurations
+  become: true
+  file:
+    state: directory
+    owner: awx
+    group: awx
+    path: "{{ tower_openshift_config_dir }}"
+
+- name: Create Directory for Prometheus
+  become: true
+  file:
+    state: directory
+    owner: awx
+    group: awx
+    path: "{{ tower_openshift_prometheus_config_dir }}"
+
+- name: Copy Prometheus Additional Rules
+  become: true
+  copy:
+    src: prometheus_additional_rule.yml
+    dest: "{{ tower_openshift_prometheus_config_dir }}/"
+    owner: awx
+    group: awx
+

--- a/roles/tower_config/templates/OSEv3.yml.j2
+++ b/roles/tower_config/templates/OSEv3.yml.j2
@@ -30,6 +30,10 @@ openshift_hosted_prometheus_deploy: true
 openshift_prometheus_node_selector:
   type: infra
 openshift_prometheus_namespace: openshift-metrics
+openshift_prometheus_args:
+  - '--storage.tsdb.retention=3d'
+  - '--web.enable-lifecycle'
+openshift_prometheus_additional_rules_file: {{ tower_openshift_prometheus_config_dir }}/prometheus_additional_rule.yml
 openshift_node_open_ports:
   - service: "Prometheus Node Exporter"
     port: "9100/tcp"

--- a/templates/alertmanager.j2
+++ b/templates/alertmanager.j2
@@ -1,0 +1,23 @@
+global:
+
+# The root route on which each incoming alert enters.
+route:
+    # default route if none match
+    receiver: alert-buffer-wh
+
+    routes:
+    - receiver: 'ansible-tower'
+      group_wait: 20s
+      group_interval: 5m
+      repeat_interval: 24h
+      match:
+        type: 'ansible-tower'
+
+receivers:
+- name: ansible-tower
+  webhook_configs:
+    - url: http://alertmanager-tower-bridge:8080
+    - url: http://localhost:9099/topics/alerts
+- name: alert-buffer-wh
+  webhook_configs:
+    - url: http://localhost:9099/topics/alerts


### PR DESCRIPTION
Support for leveraging Prometheus

To Test:

1. Full deployment of tower/OCP
2. Grant student access to Prometheus

    ```
    oc policy add-role-to-user admin <user> -n openshift-metrics
    ```

3. Confirm custom modification for Router in place in Prometheus configmap

```
    # OpenShift Router
    - job_name: openshift-routers
      scrape_interval: 30s
      scrape_timeout: 30s
      metrics_path: /metrics
      scheme: http
      static_configs:
      - targets:
        - router.default.svc.cluster.local:1936
      basic_auth:
        username: admin
        password: <password>
```

4. Verify custom alert has been configured
    1. Navigate to Prometheus UI (found by `oc get routes prometheus -n openshift-metrics`). Login and click on _Alerts_. One alert for "Minimum Number of Application Nodes" should be defined
5. Verify Alertmanager rule for ansible tower is configured

   ```
    oc export configmap alertmanager
    ```
