### PR TITLE
Letsencrypt implementation

### DIFF
--- a/letsencrypt.yml
+++ b/letsencrypt.yml
@@ -1,0 +1,31 @@
+---
+
+- hosts: localhost
+  gather_facts: no
+  vars_files:
+    - aws_vars.yml
+  vars:
+    route53_placeholder_ip: "104.67.28.83"
+  tasks:
+    - name: Create Hostnames
+      set_fact:
+        domains: "{{ domains | default('') | list }}  + ['tower-{{ lab_user }}-{{ item }}.{{ domain_name }}', 'master-{{ lab_user }}-{{ item }}.{{ domain_name }}', '*.apps-{{ lab_user }}-{{ item }}.{{ domain_name }}']"
+      with_sequence: start="{{ student_count_start }}" end="{{ student_count_end }}"
+    - name: Register route53 entries
+      route53:
+        command: create
+        aws_access_key: "{{ec2_access_key}}"
+        aws_secret_key: "{{ec2_secret_key}}"
+        zone: "{{ domain_name }}"
+        type: A
+        overwrite: True
+        ttl: 60
+        record: "{{ item }}"
+        value: "{{ route53_placeholder_ip }}"
+        wait: yes
+      with_items: "{{ domains }}"
+    - name: Letsencrypt
+      include_role:
+        name: letsencrypt
+      vars:
+        letsencrypt_domains: "{{ domains }}"

--- a/roles/letsencrypt/defaults/main.yml
+++ b/roles/letsencrypt/defaults/main.yml
@@ -1,0 +1,13 @@
+letsencrypt_staging: true
+letsencrypt_domains: []
+letsencrypt_destination_directory: "/tmp/letsencrypt"
+letsencrypt_acme_source: https://github.com/Neilpang/acme.sh/archive/2.7.8.tar.gz
+letsencrypt_acme_destination: "/tmp/acme"
+letsencrypt_num_domains_per_user: 3
+letsencrypt_max_names: 100
+letsencrypt_use_staging: true
+letsencrypt_skip_certificate_request: false
+letsencrypt_issued_fullchain_filename: letsencrypt-fullchain.crt
+letsencrypt_issued_key_filename: letsencrypt.key
+letsencrypt_issued_ca_filename: letsencrypt.ca
+letsencrypt_issued_crt_filename: letsencrypt.crt

--- a/roles/letsencrypt/tasks/assign_certificate.yml
+++ b/roles/letsencrypt/tasks/assign_certificate.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Create Directory For Certificaete
+  set_fact:
+    assign_certificate_user: "{{ lab_user }}-{{ certificate_assignment }}.{{ domain_name }}"
+
+- name: Create Directory for Assignment
+  file:
+    path: "{{ letsencrypt_destination_directory }}/{{ assign_certificate_user }}" 
+    state: directory
+
+- name: Copy Certificates to Allocated Directory
+  copy:
+    src: "{{ item }}"
+    dest: "{{ letsencrypt_destination_directory }}/{{ assign_certificate_user }}/"
+  with_items:
+    - "{{ letsencrypt_issued_ca }}"
+    - "{{ letsencrypt_issued_crt }}"
+    - "{{ letsencrypt_issued_key }}"
+    - "{{ letsencrypt_issued_fullchain }}"

--- a/roles/letsencrypt/tasks/generate_certificate.yml
+++ b/roles/letsencrypt/tasks/generate_certificate.yml
@@ -1,0 +1,56 @@
+---
+
+- name: Set Starting Point
+  set_fact:
+    letsencrypt_certificate_starting_point: "{{  (((certificate_group | int) - 1) * letsencrypt_max_domains_per_certificate) | int }}"
+
+- name: Ending Point Conditional
+  set_fact:
+    letsencrypt_certificate_ending_point_bool: "{{ ((letsencrypt_certificate_starting_point | int) + (max_domains_per_certificate | int) >  letsencrypt_domains | length) }}"
+
+
+- name: Set Ending Point
+  set_fact:
+    letsencrypt_certificate_ending_point: "{{ (letsencrypt_certificate_ending_point_bool !=  true) | ternary(letsencrypt_certificate_starting_point|int + letsencrypt_max_domains_per_certificate|int, (letsencrypt_domains | length)) }}"
+
+- name: Initialize Variables
+  set_fact:
+    domain_cmd: ""
+    staging_server: ""
+    letsencrypt_issued_base: "{{ letsencrypt_destination_directory }}/{{ lab_user }}-letsencrypt-{{ certificate_group }}.{{ domain_name }}"
+
+- name: Set Domains
+  set_fact:
+    domain_cmd: "{{ domain_cmd}} -d {{ letsencrypt_domains[item|int] }}"
+  with_sequence: start="{{ letsencrypt_certificate_starting_point }}" end="{{ (letsencrypt_certificate_ending_point | int - 1) }}"
+
+- name: Initialize Letsencrypt File Variables
+  set_fact:
+    letsencrypt_issued_fullchain: "{{ letsencrypt_issued_base }}/{{ letsencrypt_issued_fullchain_filename }}"
+    letsencrypt_issued_key: "{{ letsencrypt_issued_base }}/{{ letsencrypt_issued_key_filename }}"
+    letsencrypt_issued_ca: "{{ letsencrypt_issued_base }}/{{ letsencrypt_issued_ca_filename }}"
+    letsencrypt_issued_crt: "{{ letsencrypt_issued_base }}/{{ letsencrypt_issued_crt_filename }}"
+
+- name: Set Staging Server
+  set_fact:
+    staging_server: "--staging"
+  when: letsencrypt_use_staging
+
+- name: Create Certificate Group Directory
+  file:
+    path: "{{ letsencrypt_issued_base }}"
+    state: directory
+
+- name: Request Certificate
+  environment:
+    AWS_ACCESS_KEY_ID: "{{ ec2_access_key }}"
+    AWS_SECRET_ACCESS_KEY: "{{ ec2_secret_key }}"
+  command: >
+    {{ letsencrypt_acme_destination }}/acme.sh --debug --issue {{ staging_server }} {{ domain_cmd }} --dns dns_aws --ca-file {{ letsencrypt_issued_ca }}  --cert-file {{ letsencrypt_issued_crt }} --fullchain-file {{ letsencrypt_issued_fullchain }} --key-file {{ letsencrypt_issued_key }} --force 
+  when: letsencrypt_skip_certificate_request == false
+
+- name: Assign Certificates
+  include_tasks: assign_certificate.yml
+  with_sequence: start="{{ (((letsencrypt_certificate_starting_point | int)+1)/letsencrypt_num_domains_per_user| int) | round(0, 'ceil') | int }}" end="{{ (letsencrypt_certificate_ending_point | int /letsencrypt_num_domains_per_user | int) | round(0, 'ceil') | int }}"
+  loop_control:
+    loop_var: certificate_assignment

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+
+- name: Validate Domains Are Present
+  fail:
+    msg: No Domain Name Values Were Provided
+  when: letsencrypt_domains|length == 0
+
+- name: Validate Domains Are Present
+  fail:
+    msg: No Domain Name Values Were Provided
+  when: letsencrypt_domains|length == 0
+
+- name: Determine Maximum Number of Domains Per Certificate
+  set_fact:
+    letsencrypt_max_domains_per_certificate: "{{ ((letsencrypt_max_names/letsencrypt_num_domains_per_user) |  round(0, 'floor') | int) * letsencrypt_num_domains_per_user}}"
+
+- name: Determine Number of Certificates to Request
+  set_fact:
+    letsencrypt_num_certificate_requests: "{{ (letsencrypt_domains|length / letsencrypt_max_domains_per_certificate | int) | round(0, 'ceil') | int }}"
+
+- name: Create Directories
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - "{{ letsencrypt_acme_destination }}"
+    - "{{ letsencrypt_destination_directory }}"
+
+- name: Retrieve acme.sh
+  unarchive:
+    src: "{{ letsencrypt_acme_source }}"
+    dest: "{{ letsencrypt_acme_destination }}"
+    extra_opts: ['--strip-components=1']
+    remote_src: yes
+
+- name: Generate Certificate
+  include_tasks: generate_certificate.yml max_domains_per_certificate="{{ letsencrypt_max_domains_per_certificate }}"
+  with_sequence: start=1 end=" {{letsencrypt_num_certificate_requests }}"
+  loop_control:
+    loop_var: certificate_group
+
+- name: Show Location
+  debug:
+    msg: "Certificates have been generated in the '{{ letsencrypt_destination_directory }}' directory"

--- a/roles/tower_config/defaults/main.yml
+++ b/roles/tower_config/defaults/main.yml
@@ -246,4 +246,10 @@ tower_workflow_job_terminate_launch_poll: 0
 
 tower_openshift_config_dir: "/var/lib/aws/openshift"
 tower_openshift_prometheus_config_dir: "{{ tower_openshift_config_dir }}/prometheus"
+tower_openshift_letsencrypt_config_dir: "{{ tower_openshift_config_dir }}/letsencrypt"
+letsencrypt_base_directory: "/tmp/letsencrypt"
+letsencrypt_fullchain_filename: letsencrypt-fullchain.crt
+letsencrypt_key_filename: letsencrypt.key
+letsencrypt_ca_filename: letsencrypt.ca
+letsencrypt_crt_filename: letsencrypt.crt
 ...

--- a/roles/tower_config/tasks/inventory/groups.yml
+++ b/roles/tower_config/tasks/inventory/groups.yml
@@ -12,6 +12,26 @@
     inventory: "{{ tower_inventory }}"
     state: present
 
+- name: Register SSL Variables
+  stat:
+    path: "{{ item }}"
+  with_items:
+    - "{{ tower_openshift_letsencrypt_config_dir }}/{{ letsencrypt_crt_filename }}"
+    - "{{ tower_openshift_letsencrypt_config_dir }}/{{ letsencrypt_ca_filename }}"
+    - "{{ tower_openshift_letsencrypt_config_dir }}/{{ letsencrypt_key_filename }}"
+  register: tower_ssl_results
+
+- name: Debug SSL
+  debug:
+    var: item
+  with_items: tower_ssl_results.results
+
+- name: Set SSL Enabled Fact
+  set_fact:
+    ocp_ssl_enabled: true
+  when: item.stat.exists == true
+  with_items: "{{ tower_ssl_results.results }}"
+
 - name: Add OSEv3 Group
   tower_group:
     tower_host: "{{ tower_host }}"

--- a/roles/tower_config/tasks/letsencrypt.yml
+++ b/roles/tower_config/tasks/letsencrypt.yml
@@ -1,0 +1,22 @@
+---
+
+- name: Copy Certificates To Tower
+  copy:
+    src: "{{ letsencrypt_base_directory }}/{{ student_id }}.{{ domain_name }}/"
+    dest: "{{ tower_openshift_letsencrypt_config_dir }}"
+  become: true
+
+- name: Configure Tower SSL
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    remote_src: yes
+  with_items:
+    - { src: "{{ tower_openshift_letsencrypt_config_dir }}/{{ letsencrypt_fullchain_filename  }}", dest: "/etc/tower/tower.cert" }
+    - { src: "{{ tower_openshift_letsencrypt_config_dir }}/{{ letsencrypt_key_filename  }}", dest: "/etc/tower/tower.key" }
+  become: true
+
+- name: Restart Ansible Tower
+  command: >
+    ansible-tower-service restart
+  become: true

--- a/roles/tower_config/tasks/main.yml
+++ b/roles/tower_config/tasks/main.yml
@@ -46,6 +46,9 @@
 - import_tasks: openshift_configs.yml
   tags: openshift_configs
 
+- import_tasks: letsencrypt.yml
+  when: tower_ssl_config|bool == true
+
 - import_tasks: deauth.yml
   when: not tower_cli_credentials_keep|bool == true
   tags: deauth

--- a/roles/tower_config/tasks/openshift_configs.yml
+++ b/roles/tower_config/tasks/openshift_configs.yml
@@ -12,7 +12,10 @@
     state: directory
     owner: awx
     group: awx
-    path: "{{ tower_openshift_prometheus_config_dir }}"
+    path: "{{ item }}"
+  with_items:
+    - "{{ tower_openshift_letsencrypt_config_dir }}"
+    - "{{ tower_openshift_prometheus_config_dir }}"
 
 - name: Copy Prometheus Additional Rules
   become: true

--- a/roles/tower_config/templates/OSEv3.yml.j2
+++ b/roles/tower_config/templates/OSEv3.yml.j2
@@ -44,5 +44,11 @@ openshift_node_labels: "{{ ec2_tag_node_labels }}"
 openshift_prometheus_node_exporter_image_version: "{{ openshift_image_tag }}"
 {% endraw %}
 
+{% if ocp_ssl_enabled is defined and ocp_ssl_enabled %}
+openshift_master_overwrite_named_certificates: true
+openshift_master_named_certificates: [{"certfile": "{{ tower_openshift_letsencrypt_config_dir }}/{{ letsencrypt_crt_filename }}", "keyfile": "{{ tower_openshift_letsencrypt_config_dir }}/{{ letsencrypt_key_filename }}", "cafile": "{{ tower_openshift_letsencrypt_config_dir }}/{{ letsencrypt_ca_filename }}"}]
+openshift_hosted_router_certificate: {"certfile": "{{ tower_openshift_letsencrypt_config_dir }}/{{ letsencrypt_crt_filename }}", "keyfile": "{{ tower_openshift_letsencrypt_config_dir }}/{{ letsencrypt_key_filename }}", "cafile": "{{ tower_openshift_letsencrypt_config_dir }}/{{ letsencrypt_ca_filename }}"}
+{% endif %}
+
 # Default Node Selector Cannot be Used Due to Issue With Service Catalog Deployment. Is set during Postinstall playbook
 #osm_default_node_selector: 'type=app'

--- a/roles/tower_config/vars/full.yml
+++ b/roles/tower_config/vars/full.yml
@@ -30,4 +30,5 @@ tower_job_template_terminate_all_config: true
 tower_workflow_template_deploy_config: true
 tower_workflow_template_scaleup_config: true
 tower_workflow_template_terminate_config: true
+tower_ssl_config: false
 ...

--- a/roles/tower_config/vars/none.yml
+++ b/roles/tower_config/vars/none.yml
@@ -28,4 +28,5 @@ tower_job_template_terminate_all_config: false
 tower_workflow_template_deploy_config: false
 tower_workflow_template_scaleup_config: false
 tower_workflow_template_terminate_config: false
+tower_ssl_config: false
 ...

--- a/roles/tower_config/vars/self.yml
+++ b/roles/tower_config/vars/self.yml
@@ -31,4 +31,5 @@ tower_workflow_template_deploy_config: false
 tower_workflow_template_scaleup_config: false
 tower_workflow_template_terminate_config: false
 tower_package_config: true
+tower_ssl_config: false
 ...

--- a/roles/tower_config/vars/test.yml
+++ b/roles/tower_config/vars/test.yml
@@ -34,4 +34,5 @@ tower_job_self_configure_launch: false
 tower_workflow_job_deploy_launch: true
 tower_workflow_job_scaleup_launch: true
 tower_workflow_job_terminate_launch: false
+tower_ssl_config: false
 ...


### PR DESCRIPTION
Integration for Letsencrypt

There are two components of this integration that can be executed at different points as necessary

1. Generation of certificates from letsencrypt
2. Configuration of certificates as part of the lab launch

Test using the following steps:

1. Generate certificates by running the `letsencrypt.yml` playbook

    ```
    ansible-playbook letsencrypt.yml -e @<summit_secrets_file>
    ```
   1. New certificates should be generated in the `/tmp/letsencrypt` directory

2. Launch the lab

   1. Add the following variable to enable SSL configuration in your secrets file

    ```
    tower_ssl_config: true
    ```

    2. Launch the lab and OpenShift as per usual 

3.  Tower, OpenShift Master and Wildcard Certificates will use letsencrypt SSL certificates. 

NOTE: By default, certificates are generated against the letsencrypt staging server. There is a parameter that can be set to have it target the prod server. For certificates generated against the staging server, add [this](https://letsencrypt.org/certs/fakelerootx1.pem) to the browser certificate store for the full chain to validate