### PR TITLE
Refactor the way tower_config role is called

### DIFF
--- a/tower_config.yml
+++ b/tower_config.yml
@@ -6,6 +6,10 @@
     - ansible_ssh_user: ec2-user
   vars_files:
     - aws_vars.yml
-  roles:
-    - { role: tower_config, when: tower_config is defined }
+  tasks:
+  - include_role:
+      name: tower_config
+    when: 
+      - not tower_config | default ('none', true) == 'none'
+      - tower_config is defined
 ...


### PR DESCRIPTION
* Now if you set 'tower_config: none' the role will not be called
* This should also be true if you do not define 'tower_config'
* For now all 'none' tasks remain in case role is used stand alone, but may be removed in the future

To test, call `aws_lab_launch.yml` as normal, but set `-e tower_config=none` as such:

```
ansible-playbook aws_lab_launch.yml -e @vvaldez-secrets.yml -e tower_ami_id=ami-a4d2c0c4 -e ocp_ami_id=ami-b33022d3 -e tower_config=none
```

After the Tower VM is instantiated, the playbook should stop with the following, since it should skip the tower_config role:

```
PLAY [Include tower_config role] *************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************
Monday 30 April 2018  16:59:57 -0500 (0:00:01.373)       0:01:53.254 **********
Monday 30 April 2018  16:59:57 -0500 (0:00:01.373)       0:01:53.252 **********
ok: [tower-vvaldez-1.labs.sysdeseng.com]

TASK [include_role] **************************************************************************************************************
Monday 30 April 2018  17:00:01 -0500 (0:00:04.499)       0:01:57.754 **********
Monday 30 April 2018  17:00:01 -0500 (0:00:04.499)       0:01:57.752 **********
skipping: [tower-vvaldez-1.labs.sysdeseng.com]
```