### PR TITLE
Enable openshift-ansible-playbook install regardless of boolean

### DIFF
--- a/roles/tower_config/tasks/projects/install.yml
+++ b/roles/tower_config/tasks/projects/install.yml
@@ -4,7 +4,6 @@
     name: "{{ tower_project_install_package }}"
     state: present
   become: true
-  when: tower_prereqs_config| bool == true
 
 - name: Create symbolic link to /usr/share
   file:


### PR DESCRIPTION
* This is in case the ami does not have the package installed
* If package is installed this task occurs quickly
* This is to support 'full' and 'test'

@scollier feel free to test 'full' with this patch the same as you did last night. However, I'm also re-creating an AMI to fix this as well separately.