### PR TITLE
Refarctor static job launch option into a variable

### DIFF
--- a/roles/tower_config/defaults/main.yml
+++ b/roles/tower_config/defaults/main.yml
@@ -10,6 +10,8 @@ tower_user_add: true
 tower_cli_credentials_config: true
 tower_cli_credentials_keep: true
 tower_cli_verbosity: "--verbose"
+# For the following variable, any valid 'tower-cli workflow_job launch --help' e.g. --wait --monitor --timeout INTEGER or nothing at all to launch the workflow_job as async, 
+tower_cli_workflow_job_launch_options: "--monitor"
 
 # Tower prerequisites
 tower_prereqs_config: false

--- a/roles/tower_config/tasks/workflows/job_launch_deploy.yml
+++ b/roles/tower_config/tasks/workflows/job_launch_deploy.yml
@@ -1,6 +1,6 @@
 ---
 - name: Launch Workflow Job for Deploy - this will block while the job runs and will wait up to {{ tower_workflow_job_deploy_launch_async // 60 }} minutes to complete, see Tower UI Jobs for detailed progress
-  command: tower-cli workflow_job launch -W {{ tower_workflow_template_deploy }} --monitor {{ tower_cli_options }}
+  command: tower-cli workflow_job launch -W {{ tower_workflow_template_deploy }} {{ tower_cli_workflow_job_launch_options }} {{ tower_cli_options }}
   async: "{{ tower_workflow_job_deploy_launch_async }}"
   poll: "{{ tower_workflow_job_deploy_launch_poll }}"
 ...

--- a/roles/tower_config/tasks/workflows/job_launch_scaleup.yml
+++ b/roles/tower_config/tasks/workflows/job_launch_scaleup.yml
@@ -1,6 +1,6 @@
 ---
 - name: Launch Workflow Job for Scaleup - this will block while the job runs and will wait up to {{ tower_workflow_job_scaleup_launch_async // 60 }} minutes to complete, see Tower UI Jobs for detailed progress
-  command: tower-cli workflow_job launch -W {{ tower_workflow_template_scaleup }} --monitor {{ tower_cli_options }}
+  command: tower-cli workflow_job launch -W {{ tower_workflow_template_scaleup }} {{ tower_cli_workflow_job_launch_options }} {{ tower_cli_options }}
   async: "{{ tower_workflow_job_scaleup_launch_async }}"
   poll: "{{ tower_workflow_job_scaleup_launch_poll }}"
 ...

--- a/roles/tower_config/tasks/workflows/job_launch_terminate.yml
+++ b/roles/tower_config/tasks/workflows/job_launch_terminate.yml
@@ -1,6 +1,6 @@
 ---
 - name: Launch Workflow Job for Terminate - this will block while the job runs and will wait up to {{ tower_workflow_job_terminate_launch_async // 60 }} minutes to complete, see Tower UI Jobs for detailed progress
-  command: tower-cli workflow_job launch -W {{ tower_workflow_template_terminate }} --monitor {{ tower_cli_options }}
+  command: tower-cli workflow_job launch -W {{ tower_workflow_template_terminate }} {{ tower_cli_workflow_job_launch_options }} {{ tower_cli_options }}
   async: "{{ tower_workflow_job_terminate_launch_async }}"
   poll: "{{ tower_workflow_job_terminate_launch_poll }}"
 ...


### PR DESCRIPTION
* Instead of --monitor which actively captures all job activity
* Now a variable is available: 'tower_cli_workflow_job_launch_options'
* This variable can be any valid 'tower-cli workflow_job launch --help' option
* e.g. --wait, --monitor, --timeout INTEGER, or nothing at all to launch the workflow_job as async
* The default is '--monitor' but can be any combination as needed

@scollier try this PR with `-e tower_config=test -e tower_cli_workflow_job_launch_options=''`