### PR TITLE
Support for OpenShift 3.10

### DIFF
--- a/aws_add_node.yml
+++ b/aws_add_node.yml
@@ -13,7 +13,7 @@
         image: "{{ item.image }}"
         wait: yes
         instance_tags:
-          "{'Name': '{{ item.name }}-{{ student_id }}.{{ domain_name }}', 'lab_name': '{{ lab_name }}', 'lab_user': '{{ lab_user }}', 'lab_role': '{{ item.meta.node_type }}', 'student_id': '{{ student_id }}', 'node_labels': '{{ item.meta.node_labels | to_json }}', 'kubernetes.io/cluster/{{ student_id }}': '{{ student_id }}'}"
+          "{'Name': '{{ item.name }}-{{ student_id }}.{{ domain_name }}', 'lab_name': '{{ lab_name }}', 'lab_user': '{{ lab_user }}', 'lab_role': '{{ item.meta.node_type }}', 'student_id': '{{ student_id }}', 'node_group': '{{ item.meta.node_group }}', 'kubernetes.io/cluster/{{ student_id }}': '{{ student_id }}'}"
         vpc_subnet_id: "{{ aws_subnet_id }}"
         zone: "{{ aws_az_1 }}"
         assign_public_ip: yes

--- a/aws_create_hosts.yml
+++ b/aws_create_hosts.yml
@@ -14,7 +14,7 @@
         image: "{{ item.image }}"
         wait: yes
         instance_tags:
-          "{'Name': '{{ item.name }}-{{ student_id }}.{{ domain_name }}', 'lab_name': '{{ lab_name }}', 'lab_user': '{{ lab_user }}', 'lab_role': '{{ item.meta.node_type }}', 'student_id': '{{ student_id }}', 'node_labels': '{{ item.meta.node_labels | to_json }}', 'kubernetes.io/cluster/{{ student_id }}': '{{ student_id }}'}"
+          "{'Name': '{{ item.name }}-{{ student_id }}.{{ domain_name }}', 'lab_name': '{{ lab_name }}', 'lab_user': '{{ lab_user }}', 'lab_role': '{{ item.meta.node_type }}', 'student_id': '{{ student_id }}', 'node_group': '{{ item.meta.node_group }}', 'kubernetes.io/cluster/{{ student_id }}': '{{ student_id }}'}"
         vpc_subnet_id: "{{ aws_subnet_id }}"
         zone: "{{ aws_az_1 }}"
         assign_public_ip: yes

--- a/aws_vars.yml
+++ b/aws_vars.yml
@@ -12,7 +12,7 @@ student_count_start: 1
 student_count_end: "{{ student_count }}"
 
 ## OpenShift Version to use, this will enable the correct repositories
-openshift_deploy_version: 3.9
+openshift_deploy_version: "3.10"
 
 ## OpenShift Variables
 openshift_master_dns_prefix: "master"
@@ -69,9 +69,7 @@ aws_instances:
   image: "{{ ocp_ami_id }}"
   meta:
     node_type: 'master'
-    node_labels:
-      type: infra
-      zone: default
+    node_group: node-config-master-infra
   groups:
     - masters
     - etcd
@@ -82,9 +80,7 @@ aws_instances:
   image: "{{ ocp_ami_id }}"
   meta:
     node_type: "{{ (aws_ocp_method is defined and aws_ocp_method == 'scaleup') | ternary('new_node','node') }}"
-    node_labels:
-      type: app
-      zone: default
+    node_group: node-config-compute
   groups:
     - nodes
     - osev3

--- a/openshift_postinstall.yml
+++ b/openshift_postinstall.yml
@@ -6,7 +6,7 @@
     templates_to_keep: ['cakephp-mysql-persistent', 'metrics-deployer-template', 'registry-console']
     image_streams_to_keep: ['python', 'php', 'mysql']
     service_catalog_projects_to_annotate: ['kube-service-catalog']
-    default_node_selector: 'type=app'
+    default_node_selector: 'node-role.kubernetes.io/compute=true'
     service_catalog_default_node_selector: 'openshift-infra=apiserver'
     web_console_namespace: openshift-web-console
     tmp_configmap_prometheus: /tmp/prometheus-configmap.yml
@@ -57,10 +57,6 @@
     command: >
       oc apply -n openshift -f {{ cfme_template }}
   
-  - name: Set Default Node Selector
-    become: true
-    lineinfile: dest=/etc/origin/master/master-config.yaml  state=present regexp="defaultNodeSelector" line='  defaultNodeSelector{{ ':' }} {{ default_node_selector }}'
-
   - name: Join Prometheus and Web Console Networks
     command: >
       oc adm pod-network join-projects --to={{ openshift_prometheus_namespace }} {{ web_console_namespace }}
@@ -113,33 +109,3 @@
     command: >
       oc delete pod -n {{ openshift_prometheus_namespace }} -l=app=prometheus
 
-  - name: Locate OpenShift API Server
-    command: >
-      oc whoami --show-server=true
-    register: whoami_result
-  
-  - name: Restart OpenShift Master API
-    become: true
-    systemd:
-      name: atomic-openshift-master-api
-      state: restarted
-
-  - name: Verify API Server
-    become: true
-    command: >
-      curl --silent
-      --cacert /etc/origin/master/ca-bundle.crt
-      {{ whoami_result.stdout }}/healthz/ready
-    args:
-      warn: no
-    register: l_api_available_output
-    until: l_api_available_output.stdout == 'ok'
-    retries: 120
-    delay: 1
-    changed_when: false
-
-  - name: Delete Service Catalog Pods
-    command: >
-      oc delete pods --all -n {{ item}}
-    with_items: "{{ service_catalog_projects_to_annotate }}"
-  

--- a/roles/tower_config/files/prometheus_additional_rule.yml
+++ b/roles/tower_config/files/prometheus_additional_rule.yml
@@ -3,7 +3,7 @@ groups:
   interval: 30s # defaults to global interval
   rules:
     - alert: Minimum Number of Application Nodes
-      expr: sum(up{type="app",job="kubernetes-nodes"}) < 0
+      expr: sum(up{node_role_kubernetes_io_compute="true",job="kubernetes-nodes"}) < 0
       for: 2m
       labels:
         severity: critical

--- a/roles/tower_config/tasks/prereqs.yml
+++ b/roles/tower_config/tasks/prereqs.yml
@@ -2,7 +2,7 @@
 - name: Enable OpenShift repository
   command: >
     subscription-manager repos
-      --enable="rhel-7-server-ose-{{ openshift_deploy_version }}-rpms"
+      --enable="rhel-7-server-ose-{{ openshift_deploy_version | string }}-rpms"
   ignore_errors: yes
   become: true
 

--- a/roles/tower_config/templates/OSEv3.yml.j2
+++ b/roles/tower_config/templates/OSEv3.yml.j2
@@ -1,5 +1,6 @@
 ---
 deployment_type: openshift-enterprise
+openshift_release: "{{ openshift_deploy_version | string }}"
 osm_use_cockpit: no
 openshift_master_default_subdomain: apps-{{ student_id }}.{{ domain_name }}
 openshift_master_identity_providers:
@@ -7,29 +8,21 @@ openshift_master_identity_providers:
   login: True
   challenge: True
   kind: HTPasswdPasswordIdentityProvider
-  filename: /etc/origin/master/htpasswd
 openshift_master_htpasswd_users:
-  {{ student_id }}: $apr1$yv51mDpN$bIpurV4keQTUVt8KaXOu.0
-  {{ student_id }}-admin: $apr1$yv51mDpN$bIpurV4keQTUVt8KaXOu.0
+  {{ student_id }}: $apr1$NRjpcXlD$MVo5a7ZcexbHVRfuUkwOr0
+  {{ student_id }}-admin: $apr1$NRjpcXlD$MVo5a7ZcexbHVRfuUkwOr0
 openshift_master_image_policy_config:
   maxImagesBulkImportedPerRepository: 100
 openshift_metrics_install_metrics: yes
 os_sdn_network_plugin_name: redhat/openshift-ovs-multitenant
 osn_storage_plugin_deps: []
 openshift_schedulable: True
-openshift_hosted_router_selector: 'type=infra'
-openshift_hosted_registry_selector: 'type=infra'
-openshift_metrics_selector: "type=infra"
 openshift_cloudprovider_kind: aws
 openshift_master_cluster_hostname: "{{ openshift_master_internal_dns_prefix }}-{{ student_id }}.{{ domain_name }}"
 openshift_master_cluster_public_hostname: "{{ openshift_master_dns_prefix }}-{{ student_id }}.{{ domain_name }}"
 openshift_metrics_cassandra_storage_type: dynamic
 openshift_disable_check: memory_availability,disk_availability
-template_service_broker_selector:
-  type: infra
 openshift_hosted_prometheus_deploy: true
-openshift_prometheus_node_selector:
-  type: infra
 openshift_prometheus_namespace: openshift-metrics
 openshift_prometheus_args:
   - '--storage.tsdb.retention=3d'
@@ -43,7 +36,7 @@ ansible_service_broker_local_registry_whitelist:
 {% raw %}
 openshift_cloudprovider_aws_access_key: "{{ lookup('env','AWS_ACCESS_KEY_ID') }}"
 openshift_cloudprovider_aws_secret_key: "{{ lookup('env','AWS_SECRET_ACCESS_KEY') }}"
-openshift_node_labels: "{{ ec2_tag_node_labels }}"
+openshift_node_group_name: "{{ ec2_tag_node_group }}"
 openshift_prometheus_node_exporter_image_version: "{{ openshift_image_tag }}"
 {% endraw %}
 
@@ -53,5 +46,10 @@ openshift_master_named_certificates: [{"certfile": "{{ tower_openshift_letsencry
 openshift_hosted_router_certificate: {"certfile": "{{ tower_openshift_letsencrypt_config_dir }}/{{ letsencrypt_crt_filename }}", "keyfile": "{{ tower_openshift_letsencrypt_config_dir }}/{{ letsencrypt_key_filename }}", "cafile": "{{ tower_openshift_letsencrypt_config_dir }}/{{ letsencrypt_ca_filename }}"}
 {% endif %}
 
-# Default Node Selector Cannot be Used Due to Issue With Service Catalog Deployment. Is set during Postinstall playbook
-#osm_default_node_selector: 'type=app'
+osm_default_node_selector: "node-role.kubernetes.io/compute=true"
+openshift_metrics_cassandra_nodeselector:
+  "node-role.kubernetes.io/infra": "true"
+openshift_metrics_hawkular_nodeselector:
+  "node-role.kubernetes.io/infra": "true"
+openshift_metrics_heapster_nodeselector:
+  "node-role.kubernetes.io/infra": "true"

--- a/roles/tower_config/templates/tower_workflow_template_deploy_extra_vars.yml
+++ b/roles/tower_config/templates/tower_workflow_template_deploy_extra_vars.yml
@@ -2,6 +2,6 @@
 # Put any variables here that will be available to all members of this workflow
 lab_user: "{{ lab_user }}"
 student_id: "{{ student_id }}"
-openshift_deploy_version: "{{ openshift_deploy_version }}"
+openshift_deploy_version: "{{ openshift_deploy_version | string }}"
 openshift_cluster_public_url: "https{{':'}}//master-{{ student_id }}.{{ domain_name }}{{':'}}8443"
 openshift_clusterid: "{{ student_id }}"

--- a/templates/aws_user_data.j2
+++ b/templates/aws_user_data.j2
@@ -1,6 +1,6 @@
 #cloud-config
-hostname: "{{ item.name }}"
-fqdn: "{{ item.name }}-{{ student_id }}.{{ domain_name }}"
+#hostname: "{{ item.name }}"
+#fqdn: "{{ item.name }}-{{ student_id }}.{{ domain_name }}"
 write_files:
 - path: /etc/sudoers.d/99-ec2-user-requiretty
   permissions: '0440'


### PR DESCRIPTION
Updates to support OCP 3.10

* Had to remove setting hostname for instances
* Updated the password for OpenShift
* Removed some items that  required customizations for features that did not work in prior versions
* Updated inventory
* Verified Lab launch, OCP launch, OCP scaleup