### PR TITLE
Adding logic to generate OpenShift password

### DIFF
--- a/my_secrets.yml
+++ b/my_secrets.yml
@@ -14,6 +14,7 @@ ec2_secret_key: "your_secret_key_here"
 
 # General parameters
 tower_password: "tower_password_here"
+ocp_password: "ocp_password_here"
 aws_key_name: "your_SSH_key_name_here"
 lab_user: student
 student_count: 1

--- a/roles/tower_config/defaults/main.yml
+++ b/roles/tower_config/defaults/main.yml
@@ -254,4 +254,6 @@ letsencrypt_fullchain_filename: letsencrypt-fullchain.crt
 letsencrypt_key_filename: letsencrypt.key
 letsencrypt_ca_filename: letsencrypt.ca
 letsencrypt_crt_filename: letsencrypt.crt
+
+ocp_password: "{{ ocp_password }}"
 ...

--- a/roles/tower_config/tasks/auth.yml
+++ b/roles/tower_config/tasks/auth.yml
@@ -8,4 +8,13 @@
 - name: Set Tower CLI Password
   command: tower-cli config password {{ tower_password }}
   no_log: True
+
+- name: Generate OpenShift Password
+  command: htpasswd -b -n ocp {{ ocp_password }}
+  register: ocp_htpasswd_result
+  no_log: True
+
+- name: Set OpenShift Password Fact
+  set_fact:
+    ocp_htpasswd: "{{ ocp_htpasswd_result.stdout.split(':')[1] }}"
 ...

--- a/roles/tower_config/templates/OSEv3.yml.j2
+++ b/roles/tower_config/templates/OSEv3.yml.j2
@@ -9,8 +9,8 @@ openshift_master_identity_providers:
   challenge: True
   kind: HTPasswdPasswordIdentityProvider
 openshift_master_htpasswd_users:
-  {{ student_id }}: $apr1$NRjpcXlD$MVo5a7ZcexbHVRfuUkwOr0
-  {{ student_id }}-admin: $apr1$NRjpcXlD$MVo5a7ZcexbHVRfuUkwOr0
+  {{ student_id }}: {{ ocp_htpasswd }}
+  {{ student_id }}-admin: {{ ocp_htpasswd }}
 openshift_master_image_policy_config:
   maxImagesBulkImportedPerRepository: 100
 openshift_metrics_install_metrics: yes

--- a/roles/tower_config/templates/tower_job_template_self_configure_extra_vars.yml.j2
+++ b/roles/tower_config/templates/tower_job_template_self_configure_extra_vars.yml.j2
@@ -41,5 +41,6 @@ ocp_ami_id: "{{ ocp_ami_id }}"
 tower_inst_type: "{{ tower_inst_type }}"
 ocp_master_inst_type: "{{ ocp_master_inst_type }}"
 ocp_node_inst_type: "{{ ocp_node_inst_type }}"
+ocp_password: "{{ ocp_password }}"
 ami_httpd_inst_type: "{{ ami_httpd_inst_type }}"
 ...


### PR DESCRIPTION
Generates OpenShift password

To Test:

Add the following in your secrets file

```
ocp_password: <password>
```

To Validate

1. Run Lab Launch to deploy tower
2. Launch Self-Configure Job Template
3. Verify _htpasswd_ based password generated in the `OSEv3` OpenShift inventory group.