### PR TITLE
Remove prereq job from workflow

### DIFF
--- a/roles/tower_config/templates/tower_workflow_template_deploy_schema.yml
+++ b/roles/tower_config/templates/tower_workflow_template_deploy_schema.yml
@@ -1,8 +1,6 @@
 ---
 - job_template: "{{ tower_job_template_deploy_provision }}"
   success_nodes:
-  - job_template: "{{ tower_job_template_deploy_prerequisites }}"
+  - job_template: "{{ tower_job_template_deploy_install }}"
     success_nodes:
-    - job_template: "{{ tower_job_template_deploy_install }}"
-      success_nodes:
-      - job_template: "{{ tower_job_template_deploy_configure }}"
+    - job_template: "{{ tower_job_template_deploy_configure }}"


### PR DESCRIPTION
remove prereq job template from workflow. job template is still created, but not executed.